### PR TITLE
Adds skeleton retrieval of Transaction functionality to AccountsDocumentInfoServiceImpl

### DIFF
--- a/document-generator-accounts/pom.xml
+++ b/document-generator-accounts/pom.xml
@@ -27,11 +27,12 @@
         <!--Dependencies-->
         <spring-boot-start-web.version>2.0.4.RELEASE</spring-boot-start-web.version>
         <api-sdk-java.version>2.0.0-rc1</api-sdk-java.version>
-        <environment-reader-library.version>1.0.0-rc1</environment-reader-library.version>
-        <structured-logging.version>1.2.0-rc1</structured-logging.version>
+        <environment-reader-library.version>1.2.0-rc1</environment-reader-library.version>
+        <structured-logging.version>1.3.0-rc1</structured-logging.version>
 
         <!-- JUnit Testing -->
         <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
+        <mockito-junit-jupiter.version>2.18.0</mockito-junit-jupiter.version>
     </properties>
 
     <dependencies>
@@ -56,15 +57,23 @@
             <version>unversioned</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring-boot-start-web.version}</version>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit-jupiter-engine.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-            <version>${spring-boot-start-web.version}</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito-junit-jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/document-generator-accounts/pom.xml
+++ b/document-generator-accounts/pom.xml
@@ -21,25 +21,50 @@
         <!-- Encoding -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- JUnit Testing -->
-        <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
-
         <!-- JDK Version -->
         <jdk.version>1.8</jdk.version>
+
+        <!--Dependencies-->
+        <spring-boot-start-web.version>2.0.4.RELEASE</spring-boot-start-web.version>
+        <api-sdk-java.version>2.0.0-rc1</api-sdk-java.version>
+        <environment-reader-library.version>1.0.0-rc1</environment-reader-library.version>
+        <structured-logging.version>1.2.0-rc1</structured-logging.version>
+
+        <!-- JUnit Testing -->
+        <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-sdk-java</artifactId>
+            <version>${api-sdk-java.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>environment-reader-library</artifactId>
+            <version>${environment-reader-library.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>structured-logging</artifactId>
+            <version>${structured-logging.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
             <artifactId>document-generator-interfaces</artifactId>
             <version>unversioned</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit-jupiter-engine.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring-boot-start-web.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
@@ -27,6 +27,7 @@ public class AccountsDocumentInfoServiceImpl implements DocumentInfoService {
 
         Transaction transaction = transactionService.getTransaction(resource);
         if (transaction == null) {
+            LOG.error("transaction not found");
             return null;
         }
 

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.document.generator.accounts;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.document.generator.accounts.service.TransactionService;
 import uk.gov.companieshouse.document.generator.interfaces.DocumentInfoService;
@@ -9,7 +9,7 @@ import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfo;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
-@Component
+@Service
 public class AccountsDocumentInfoServiceImpl implements DocumentInfoService {
 
     @Autowired

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
@@ -1,12 +1,36 @@
 package uk.gov.companieshouse.document.generator.accounts;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.document.generator.accounts.service.TransactionService;
 import uk.gov.companieshouse.document.generator.interfaces.DocumentInfoService;
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfo;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
+@Component
 public class AccountsDocumentInfoServiceImpl implements DocumentInfoService {
+
+    @Autowired
+    private TransactionService transactionService;
+
+    public static final String MODULE_NAME_SPACE = "document-generator-accounts";
+
+    private static final Logger LOG = LoggerFactory.getLogger(MODULE_NAME_SPACE);
 
     @Override
     public DocumentInfo getDocumentInfo() {
+        LOG.info("Started getting document");
+
+        String resource = "";
+
+        Transaction transaction = transactionService.getTransaction(resource);
+        if (transaction == null) {
+            return null;
+        }
+
         return null;
+
     }
 }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
@@ -30,7 +30,7 @@ public class AccountsDocumentInfoServiceImpl implements DocumentInfoService {
             return null;
         }
 
-        return null;
+        return new DocumentInfo();
 
     }
 }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/transaction/TransactionManager.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/transaction/TransactionManager.java
@@ -11,15 +11,14 @@ import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
 
 public class TransactionManager {
 
-
     /** represents the Authorization header name in the request */
     private static final String AUTHORIZATION_HEADER = "Authorization";
 
+    /** represents the Spring rest template that is created for cross microservice contact */
     private static final RestTemplate restTemplate = createRestTemplate();
 
-
     /**
-     * Try get transaction if exists
+     * Get transaction if exists
      *
      * @param id - transaction id
      * @return transaction object along with the status or not found status.
@@ -35,7 +34,7 @@ public class TransactionManager {
     }
 
     /**
-     * Creates the rest template when class first loads
+     * Creates the rest template when class is initialised
      *
      * @return Returns a statically created rest template
      */
@@ -55,25 +54,28 @@ public class TransactionManager {
     }
 
     /**
-     * Get the root uri from the properties file
+     * Get the API_URL environment variable
      *
-     * @return Get the root uri if set, otherwise throw an exception
+     * @return Get the API_URL if set, otherwise throw an exception
      */
     private static String getRootUri() {
         return new EnvironmentReaderImpl().getMandatoryString("API_URL");
     }
 
-
     /**
      * Gets the api key environment variable
      *
-     * @return Returns the api key if set
+     * @return Returns the api key if set, otherwise throw an exception
      */
     private static String getApiKey() {
         return new EnvironmentReaderImpl().getMandatoryString("CHS_API_KEY");
     }
 
-
+    /**
+     * Builds the private transaction link with the transaction id
+     *
+     * @return Returns the private endpoint transaction url with the transaction id
+     */
     private static String getBaseUrl(String id) {
         return "/private/transactions/" + id;
     }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/transaction/TransactionManager.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/transaction/TransactionManager.java
@@ -1,0 +1,80 @@
+package uk.gov.companieshouse.document.generator.accounts.data.transaction;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
+
+public class TransactionManager {
+
+
+    /** represents the Authorization header name in the request */
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private static final RestTemplate restTemplate = createRestTemplate();
+
+
+    /**
+     * Try get transaction if exists
+     *
+     * @param id - transaction id
+     * @return transaction object along with the status or not found status.
+     */
+    public static ResponseEntity<Transaction> getTransaction(String id) {
+        HttpHeaders requestHeaders = new HttpHeaders();
+        requestHeaders.set(AUTHORIZATION_HEADER, getApiKey());
+
+        HttpEntity requestEntity = new HttpEntity(requestHeaders);
+        String url = getBaseUrl(id);
+
+        return getTransaction(url, requestEntity);
+    }
+
+    /**
+     * Creates the rest template when class first loads
+     *
+     * @return Returns a statically created rest template
+     */
+    private static RestTemplate createRestTemplate() {
+        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
+        return new RestTemplate(requestFactory);
+    }
+
+    /**
+     * GET the transaction resource
+     *
+     * @param url - url to send the get request
+     * @param requestEntity - the request entity object
+     */
+    private static ResponseEntity<Transaction> getTransaction(String url, HttpEntity requestEntity) {
+        return restTemplate.exchange(getRootUri() + url, HttpMethod.GET, requestEntity, Transaction.class);
+    }
+
+    /**
+     * Get the root uri from the properties file
+     *
+     * @return Get the root uri if set, otherwise throw an exception
+     */
+    private static String getRootUri() {
+        return new EnvironmentReaderImpl().getMandatoryString("API_URL");
+    }
+
+
+    /**
+     * Gets the api key environment variable
+     *
+     * @return Returns the api key if set
+     */
+    private static String getApiKey() {
+        return new EnvironmentReaderImpl().getMandatoryString("CHS_API_KEY");
+    }
+
+
+    private static String getBaseUrl(String id) {
+        return "/private/transactions/" + id;
+    }
+}

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/transaction/TransactionManager.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/transaction/TransactionManager.java
@@ -22,6 +22,10 @@ public class TransactionManager {
     /** represents the Spring rest template that is created for cross microservice contact */
     private static final RestTemplate restTemplate = createRestTemplate();
 
+    private TransactionManager() {
+        // private constructor inserted to hide implicit public one
+    }
+
     /**
      * Get transaction if exists
      *
@@ -82,6 +86,6 @@ public class TransactionManager {
      * @return Returns the private endpoint transaction url with the transaction id
      */
     private static String getBaseUrl(String id) {
-        return "/private/transactions/" + id;
+        return new StringBuilder("/private/transactions/").append(id).toString();
     }
 }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/transaction/TransactionManager.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/transaction/TransactionManager.java
@@ -9,6 +9,11 @@ import org.springframework.web.client.RestTemplate;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
 
+/**
+ * TransactionManager is the current temporary internal project solution for communicating with
+ * microservices internally. This will be replaced by the private-sdk and its use shall be replaced
+ * in the service layer also.
+ */
 public class TransactionManager {
 
     /** represents the Authorization header name in the request */

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/TransactionService.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/TransactionService.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.document.generator.accounts.service;
+
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+public interface TransactionService {
+
+    /**
+     * Call the api sdk to get transaction of id passed.
+     *
+     * __NOTE:__: It is important to note, currently it will call an internal transaction manager
+     * within this project that calls the transactions api through ERIC as the private sdk hasn't
+     * been built yet. When the private SDK has been built, we should be able to simply delete the
+     * transaction package and use the SDK in the implementation of this method.
+     *
+     * @return transaction
+     */
+    Transaction getTransaction(String id);
+}

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/impl/TransactionServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/impl/TransactionServiceImpl.java
@@ -1,0 +1,35 @@
+package uk.gov.companieshouse.document.generator.accounts.service.impl;
+
+import static uk.gov.companieshouse.document.generator.accounts.AccountsDocumentInfoServiceImpl.MODULE_NAME_SPACE;
+
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.document.generator.accounts.data.transaction.TransactionManager;
+import uk.gov.companieshouse.document.generator.accounts.service.TransactionService;
+
+@Service
+public class TransactionServiceImpl implements TransactionService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MODULE_NAME_SPACE);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Transaction getTransaction(String id) {
+        LOG.info("Getting data from transactions-api");
+
+        ResponseEntity<Transaction> transaction = TransactionManager.getTransaction(id);
+
+        if (transaction.getStatusCode() != HttpStatus.OK) {
+            LOG.error(String.format("Failed to retrieve data from API: %s", id));
+            return null;
+        }
+        LOG.trace("Transaction data retrieved successfully");
+        return transaction.getBody();
+    }
+}

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImplTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImplTest.java
@@ -1,5 +1,44 @@
 package uk.gov.companieshouse.document.generator.accounts;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.document.generator.accounts.service.TransactionService;
+import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfo;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
 public class AccountsDocumentInfoServiceImplTest {
+
+    @InjectMocks
+    private AccountsDocumentInfoServiceImpl accountsDocumentInfoService;
+
+    @Mock
+    private TransactionService transactionService;
+
+    @Test
+    @DisplayName("Tests the successful retrieval of an accounts document data")
+    void testSuccessfulGetDocumentInfo() {
+        when(transactionService.getTransaction(anyString())).thenReturn(new Transaction());
+        assertEquals(DocumentInfo.class, accountsDocumentInfoService.getDocumentInfo().getClass());
+    }
+
+    @Test
+    @DisplayName("Tests the unsuccessful retrieval of an accounts document data due to error in transaction retrieval")
+    void testUnsuccessfulGetDocumentInfo() {
+        when(transactionService.getTransaction(anyString())).thenReturn(null);
+        assertNull(accountsDocumentInfoService.getDocumentInfo());
+    }
 
 }

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/service/impl/TransactionServiceImplTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/service/impl/TransactionServiceImplTest.java
@@ -1,0 +1,5 @@
+package uk.gov.companieshouse.document.generator.accounts.service.impl;
+
+public class TransactionServiceImplTest {
+
+}


### PR DESCRIPTION
- adds retrieval of transaction functionality
- adds `TransactionManager` that calls the `transactions-api` through `ERIC` to get the correct transaction data
- adds service layer that calls the `TransactionManager`

**Note:** It's important to note that the `TransactionManager` will be removed once the `private-sdk` is implemented. When that has been done, then the `TransactionService` simple uses the `private-sdk` rather than the internal project `TransactionManager` as the purpose of the `TransactionManager` is simply to mimic what the `private-sdk` does. Additionally, it is important to note that there are no tests for the `TransactionService` as it cannot test the `TransactionManager` due to static methods. When the `private-sdk` has been implemented, the `TransactionService` can then be tested. Until then, there will be empty tests.

Implements: SFA-567