### PR TITLE
Added Abridged account logic to determine if accounts is abridged

### DIFF
--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
@@ -49,12 +49,12 @@ public class AccountsDocumentInfoServiceImpl implements DocumentInfoService {
     }
 
     /**
-     * determines whether it is an abridged link as /accounts/ only exists within the abridged
-     * implementation
+     * determines whether it is an abridged link as "/transactions/{transactionId}/accounts/{accountsId}"
+     * only exists within the abridged implementation
      * @param accountLink - account link
      * @return true if abridged, false if not
      */
     private boolean isAbridged(String accountLink) {
-        return accountLink.contains("/accounts/");
+        return accountLink.matches("/transactions/\\d+(\\-\\d+)+/accounts/\\w+?=");
     }
 }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
@@ -34,24 +34,17 @@ public class AccountsDocumentInfoServiceImpl implements DocumentInfoService {
             return null;
         }
 
-        String accountLink = Optional.of(transaction)
+        return Optional.of(transaction)
                 .map(Transaction::getResources)
                 .map(resources -> resources.get(resourceId))
                 .map(Resource::getLinks)
                 .map(links -> links.get("resource"))
-                .orElseGet(() -> {
-                    LOG.error("Unable to find account resource link in transaction under:" + resourceId);
-                    return Optional.empty().toString();
-                });
-
-        // when abridged has been migrated to use the company-accounts api, the code for the
-        // company accounts should work for abridged, resulting in this abridged specific code
-        // qualifying for removal
-        if (isAbridged(accountLink)) {
-            return new DocumentInfo();
-        }
-
-        return null;
+                // when abridged has been migrated to use the company-accounts api, the code for the
+                // company accounts should work for abridged, resulting in this abridged specific code
+                // qualifying for removal
+                .filter(this::isAbridged)
+                .map(accountsLinks -> new DocumentInfo())
+                .orElse(null);
 
     }
 
@@ -63,5 +56,9 @@ public class AccountsDocumentInfoServiceImpl implements DocumentInfoService {
      */
     private boolean isAbridged(String accountLink) {
         return accountLink.contains("/accounts/");
+    }
+
+    private DocumentInfo smallFull(String accountLink) {
+        return new DocumentInfo();
     }
 }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
@@ -36,9 +36,9 @@ public class AccountsDocumentInfoServiceImpl implements DocumentInfoService {
 
         String accountLink = Optional.of(transaction)
                 .map(Transaction::getResources)
-                .map(e -> e.get(resourceId))
+                .map(resources -> resources.get(resourceId))
                 .map(Resource::getLinks)
-                .map(e -> e.get("resource"))
+                .map(links -> links.get("resource"))
                 .orElseGet(() -> {
                     LOG.error("Unable to find account resource link in transaction under:" + resourceId);
                     return Optional.empty().toString();

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
@@ -57,8 +57,4 @@ public class AccountsDocumentInfoServiceImpl implements DocumentInfoService {
     private boolean isAbridged(String accountLink) {
         return accountLink.contains("/accounts/");
     }
-
-    private DocumentInfo smallFull(String accountLink) {
-        return new DocumentInfo();
-    }
 }

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImplTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImplTest.java
@@ -36,7 +36,7 @@ public class AccountsDocumentInfoServiceImplTest {
         Map<String, Resource> resources = new HashMap<>();
         resources.put("error", createResource());
 
-        Transaction transaction = new Transaction().;
+        Transaction transaction = new Transaction();
         transaction.setResources(resources);
         when(transactionService.getTransaction(anyString())).thenReturn(transaction);
 

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImplTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImplTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.transaction.Resource;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.document.generator.accounts.service.TransactionService;
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfo;
@@ -28,17 +31,45 @@ public class AccountsDocumentInfoServiceImplTest {
     private TransactionService transactionService;
 
     @Test
-    @DisplayName("Tests the successful retrieval of an accounts document data")
-    void testSuccessfulGetDocumentInfo() {
-        when(transactionService.getTransaction(anyString())).thenReturn(new Transaction());
-        assertEquals(DocumentInfo.class, accountsDocumentInfoService.getDocumentInfo().getClass());
+    @DisplayName("Tests the unsuccessful retrieval of an accounts document data due to no accounts resource in transaction")
+    void testUnsuccessfulGetDocumentInfoNoAccountsResourceInTransaction() {
+        Map<String, Resource> resources = new HashMap<>();
+        resources.put("error", createResource());
+
+        Transaction transaction = new Transaction().;
+        transaction.setResources(resources);
+        when(transactionService.getTransaction(anyString())).thenReturn(transaction);
+
+        assertNull(accountsDocumentInfoService.getDocumentInfo());
     }
 
     @Test
     @DisplayName("Tests the unsuccessful retrieval of an accounts document data due to error in transaction retrieval")
-    void testUnsuccessfulGetDocumentInfo() {
+    void testUnsuccessfulGetDocumentInfoFailedTransactionRetrieval() {
         when(transactionService.getTransaction(anyString())).thenReturn(null);
         assertNull(accountsDocumentInfoService.getDocumentInfo());
+    }
+
+    @Test
+    @DisplayName("Tests the successful retrieval of an abridged accounts document data")
+    void testSuccessfulGetDocumentInfo() {
+        Map<String, Resource> resources = new HashMap<>();
+        resources.put("", createResource());
+
+        Transaction transaction = new Transaction();
+        transaction.setResources(resources);
+        when(transactionService.getTransaction(anyString())).thenReturn(transaction);
+
+        assertEquals(DocumentInfo.class, accountsDocumentInfoService.getDocumentInfo().getClass());
+    }
+
+    private Resource createResource() {
+        Resource resource = new Resource();
+        resource.setKind("kind");
+        Map<String, String> links = new HashMap<>();
+        links.put("resource", "/transactions/175725-236115-324362/accounts/wQSM2bWmQR3zrIw3x7apJOBjzWY=");
+        resource.setLinks(links);
+        return resource;
     }
 
 }


### PR DESCRIPTION
- gets and checks resource in transaction is abridged accounts and if so, it does some abridged logic (to be implemented in next PR - currently it just returns an empty `DocumentInfo` object to split functionality across smaller PRs.
- added unit tests to cover new scenarios of no transaction and no account resource

Implements: SFA-567