### PR TITLE
document-generator swagger specs for api

### DIFF
--- a/document-generator-core/swagger-2.0/models/document-generator.json
+++ b/document-generator-core/swagger-2.0/models/document-generator.json
@@ -52,7 +52,7 @@
         },
         "size": {
           "type": "string",
-          "description": "size of the document stored"
+          "description": "Long value to denote the size of the document stored"
         },
         "description": {
           "type": "string",
@@ -64,10 +64,9 @@
         },
         "description_values": {
           "type": "object",
-          "description": "List of resources contained within this transaction.",
+          "description": "a map of key/value pairs used to complete the looked up description identifier enum to turn it into a full description",
           "additionalProperties":{
-            "type": "string",
-            "description": "Map of resource 'identifier' to resource object"
+            "type": "string"
           }
         }
       }

--- a/document-generator-core/swagger-2.0/models/document-generator.json
+++ b/document-generator-core/swagger-2.0/models/document-generator.json
@@ -3,56 +3,49 @@
     "documentRequest": {
       "title": "DocumentRequest",
       "required": [
-        "id",
-        "resource",
+        "resource_uri",
         "resource_id",
-        "content_type",
-        "document_type",
-        "user_id"
+        "mime_type"
       ],
       "properties": {
-        "id": {
+        "resource_uri": {
           "type": "string",
-          "description": "id for the document request"
-        },
-        "resource": {
-          "type": "string",
-          "description": "link to the resource"
+          "description": "link to the resource (currently it is the link to the parent transaction)"
         },
         "resource_id": {
           "type": "string",
-          "description": "id of the resource"
+          "description": "id of the resource (currently denotes which resource within the transaction)"
         },
-        "content_type": {
+        "mime_type": {
           "type": "string",
-          "description": "the content type of the template to be converted"
+          "description": "mime type that the document should be rendered as"
         },
         "document_type": {
           "type": "string",
-          "description": "type of document to be rendered"
-        },
-        "user_id": {
-          "type": "string",
-          "description": "id of the user requesting the document"
+          "description": "indicates the document or report type to be generated from the resource data. Currently not implemented"
         }
+
       }
     },
     "documentResponse": {
       "title": "DocumentResponse",
       "required": [
-        "location",
+        "links",
         "size",
         "description",
         "description_identifier",
       ],
       "properties": {
-        "location": {
-          "type": "string",
-          "description": "location that the document has been stored"
+        "links": {
+          "type": "object",
+          "description": "links to related resources",
+          "items": {
+            "$ref": "http://localhost:3123/swagger-2.0/models/document-generator.json#/definitions/documentLinks"
+          }
         },
         "size": {
           "type": "string",
-          "description": "Long value to denote the size of the document stored"
+          "description": "value to denote the size of the document stored in bytes"
         },
         "description": {
           "type": "string",
@@ -68,6 +61,18 @@
           "additionalProperties":{
             "type": "string"
           }
+        }
+      }
+    },
+    "documentLinks": {
+      "title": "DocumentLinks",
+      "required": [
+        "location"
+      ],
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "location that the document has been stored"
         }
       }
     }

--- a/document-generator-core/swagger-2.0/models/document-generator.json
+++ b/document-generator-core/swagger-2.0/models/document-generator.json
@@ -1,7 +1,7 @@
 {
   "definitions": {
-    "documentGeneratorRequest": {
-      "title": "DocumentGeneratorRequest",
+    "documentRequest": {
+      "title": "DocumentRequest",
       "required": [
         "id",
         "resource",
@@ -37,8 +37,8 @@
         }
       }
     },
-    "documentGeneratorResponse": {
-      "title": "DocumentGeneratorResponse",
+    "documentResponse": {
+      "title": "DocumentResponse",
       "required": [
         "location",
         "size",

--- a/document-generator-core/swagger-2.0/models/document-generator.json
+++ b/document-generator-core/swagger-2.0/models/document-generator.json
@@ -1,0 +1,76 @@
+{
+  "definitions": {
+    "documentGeneratorRequest": {
+      "title": "DocumentGeneratorRequest",
+      "required": [
+        "id",
+        "resource",
+        "resource_id",
+        "content_type",
+        "document_type",
+        "user_id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "id for the document request"
+        },
+        "resource": {
+          "type": "string",
+          "description": "link to the resource"
+        },
+        "resource_id": {
+          "type": "string",
+          "description": "id of the resource"
+        },
+        "content_type": {
+          "type": "string",
+          "description": "the content type of the template to be converted"
+        },
+        "document_type": {
+          "type": "string",
+          "description": "type of document to be rendered"
+        },
+        "user_id": {
+          "type": "string",
+          "description": "id of the user requesting the document"
+        }
+      }
+    },
+    "documentGeneratorResponse": {
+      "title": "DocumentGeneratorResponse",
+      "required": [
+        "location",
+        "size",
+        "description",
+        "description_identifier",
+      ],
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "location that the document has been stored"
+        },
+        "size": {
+          "type": "string",
+          "description": "size of the document stored"
+        },
+        "description": {
+          "type": "string",
+          "description": "description of the document produced"
+        },
+        "description_identifier": {
+          "type": "string",
+          "description": "Identifier for the document description"
+        },
+        "description_values": {
+          "type": "object",
+          "description": "List of resources contained within this transaction.",
+          "additionalProperties":{
+            "type": "string",
+            "description": "Map of resource 'identifier' to resource object"
+          }
+        }
+      }
+    }
+  }
+}

--- a/document-generator-core/swagger-2.0/spec/document-generator.json
+++ b/document-generator-core/swagger-2.0/spec/document-generator.json
@@ -47,8 +47,8 @@
           "400": {
             "description": "Unable to handle given request"
           },
-          "404": {
-            "description": "Resource has not been found"
+          "401": {
+            "description": "Not authorized to add the resource "
           }
         }
       }

--- a/document-generator-core/swagger-2.0/spec/document-generator.json
+++ b/document-generator-core/swagger-2.0/spec/document-generator.json
@@ -1,0 +1,57 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Document generator API",
+    "description": "An API for generation of documents",
+    "version": "1.0.0"
+  },
+  "host": "localhost",
+  "schemes": [
+    "http"
+  ],
+  "tags": [
+    {
+    "name": "document-generator"
+    }
+  ],
+  "paths": {
+    "/document-generate": {
+      "post": {
+        "x-operationName": "generate",
+        "summary": "Generation of documents",
+        "description": "Generate a document using the request to obtain the document data and send to render service",
+        "tags": [
+          "document-generator"
+        ],
+        "consumes": [
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "data",
+            "in": "body",
+            "description": "required parameters to generate a document",
+            "required": true,
+            "schema": {
+              "$ref": "http://localhost:3123/swagger-2.0/models/document-generator.json#/definitions/documentGeneratorRequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The document has been created",
+            "schema": {
+              "$ref": "http://localhost:3123/swagger-2.0/models/document-generator.json#/definitions/documentGeneratorResponse"
+            }
+          },
+          "400": {
+            "description": "Unable to handle given request"
+          },
+          "404": {
+            "description": "Resource has not been found"
+          }
+        }
+      }
+    }
+  }
+}

--- a/document-generator-core/swagger-2.0/spec/document-generator.json
+++ b/document-generator-core/swagger-2.0/spec/document-generator.json
@@ -33,7 +33,7 @@
             "description": "A DocumentRequest resource",
             "required": true,
             "schema": {
-              "$ref": "http://localhost:3123/swagger-2.0/models/document-generator.json#/definitions/documentGeneratorRequest"
+              "$ref": "http://localhost:3123/swagger-2.0/models/document-generator.json#/definitions/documentRequest"
             }
           }
         ],
@@ -41,7 +41,7 @@
           "201": {
             "description": "The document has been created",
             "schema": {
-              "$ref": "http://localhost:3123/swagger-2.0/models/document-generator.json#/definitions/documentGeneratorResponse"
+              "$ref": "http://localhost:3123/swagger-2.0/models/document-generator.json#/definitions/documentResponse"
             }
           },
           "400": {

--- a/document-generator-core/swagger-2.0/spec/document-generator.json
+++ b/document-generator-core/swagger-2.0/spec/document-generator.json
@@ -15,11 +15,11 @@
     }
   ],
   "paths": {
-    "/document-generate": {
+    "/private/documents/generate": {
       "post": {
         "x-operationName": "generate",
         "summary": "Generation of documents",
-        "description": "Generate a document using the request to obtain the document data and send to render service",
+        "description": "Takes a URI of a resource and synchronously generates a document of the requested mime type",
         "tags": [
           "document-generator"
         ],
@@ -30,7 +30,7 @@
           {
             "name": "data",
             "in": "body",
-            "description": "required parameters to generate a document",
+            "description": "A DocumentRequest resource",
             "required": true,
             "schema": {
               "$ref": "http://localhost:3123/swagger-2.0/models/document-generator.json#/definitions/documentGeneratorRequest"
@@ -45,10 +45,10 @@
             }
           },
           "400": {
-            "description": "Unable to handle given request"
+            "description": "Error within the request body, missing or mismatched parameters detected"
           },
           "401": {
-            "description": "Not authorized to add the resource "
+            "description": "not authorised to process request"
           }
         }
       }


### PR DESCRIPTION
Created a new swagger spec for document-generator as document-generator-core will now become an API. 

New model also created to spec the request and response model the api will use. 
Currently as this is a private spec it is situated within document-generator-core under the folder swagger-2.0. Tested and run through dappperdox.

Resolves SFA - 664