### PR TITLE
Adds accounts service layer

### DIFF
--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/accounts/AccountsManager.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/accounts/AccountsManager.java
@@ -59,7 +59,7 @@ public class AccountsManager {
         if (accountsResponseEntity.getStatusCode() != HttpStatus.OK) {
             Map<String, Object> logMap = new HashMap<>();
             logMap.put("resource", link);
-            logMap.put("data.status", accountsResponseEntity.getStatusCode());
+            logMap.put("status", accountsResponseEntity.getStatusCode());
             LOG.error("Failed to retrieve data from API", logMap);
 
             throw new Exception("Failed to retrieve data from API");

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/accounts/AccountsManager.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/accounts/AccountsManager.java
@@ -12,7 +12,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
-import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.model.accounts.Accounts;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
@@ -44,6 +43,10 @@ public class AccountsManager {
      *
      * @param link - self link for the accounts object
      * @return accounts object along with the status or not found status.
+     * @throws Exception - throws a generic exception to mimic the private sdk throwing an exception.
+     *                     We're not to create a custom exception as it will have to be removed when
+     *                     the private sdk  gets implemented - additionally the generic exception is
+     *                     sufficient
      */
     public Accounts getAccounts(String link) throws Exception {
         HttpHeaders requestHeaders = new HttpHeaders();
@@ -58,10 +61,7 @@ public class AccountsManager {
             logMap.put("resource", link);
             logMap.put("data.status", accountsResponseEntity.getStatusCode());
             LOG.error("Failed to retrieve data from API", logMap);
-
-            // we are throwing a generic exception to mimic the private sdk throwing an exception.
-            // We're not to create a custom exception as it will have to be removed when the private sdk
-            // gets implemented - additionally the generic exception is sufficient
+            
             throw new Exception("Failed to retrieve data from API");
         }
         return accountsResponseEntity.getBody();

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/accounts/AccountsManager.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/accounts/AccountsManager.java
@@ -31,8 +31,8 @@ public class AccountsManager {
 
     private static final EnvironmentReader READER = new EnvironmentReaderImpl();
 
-    private final String API_URL = READER.getMandatoryString("API_URL");
-    private final String CHS_API_KEY = READER.getMandatoryString("CHS_API_KEY");
+    private final String apiUrl = READER.getMandatoryString("API_URL");
+    private final String chsApiKey = READER.getMandatoryString("CHS_API_KEY");
 
     private static final RestTemplate restTemplate = createRestTemplate();
 
@@ -61,7 +61,7 @@ public class AccountsManager {
             logMap.put("resource", link);
             logMap.put("data.status", accountsResponseEntity.getStatusCode());
             LOG.error("Failed to retrieve data from API", logMap);
-            
+
             throw new Exception("Failed to retrieve data from API");
         }
         return accountsResponseEntity.getBody();
@@ -78,10 +78,10 @@ public class AccountsManager {
     }
 
     private String getRootUri() {
-        return API_URL;
+        return apiUrl;
     }
 
     private String getApiKey() {
-        return CHS_API_KEY;
+        return chsApiKey;
     }
 }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/exception/ServiceException.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/exception/ServiceException.java
@@ -5,5 +5,4 @@ public class ServiceException extends Exception {
     public ServiceException(String message, Throwable cause) {
         super(message, cause);
     }
-
 }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/exception/ServiceException.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/exception/ServiceException.java
@@ -1,0 +1,9 @@
+package uk.gov.companieshouse.document.generator.accounts.exception;
+
+public class ServiceException extends Exception {
+
+    public ServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/AccountsService.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/AccountsService.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.document.generator.accounts.service;
 
 import uk.gov.companieshouse.api.model.accounts.Accounts;
+import uk.gov.companieshouse.document.generator.accounts.exception.ServiceException;
 
 public interface AccountsService {
 
@@ -12,6 +13,7 @@ public interface AccountsService {
      * (SFA-518, SFA-670), we can replace the internal sdk solution with private-sdk calls.
      *
      * @return accounts - base accounts resource
+     * @throws ServiceException - throws a service exception
      */
-    Accounts getAccounts(String resource);
+    Accounts getAccounts(String resource) throws ServiceException;
 }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/AccountsService.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/AccountsService.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.document.generator.accounts.service;
+
+import uk.gov.companieshouse.api.model.accounts.Accounts;
+
+public interface AccountsService {
+
+    /**
+     * Call to private-sdk to get accounts resource data.
+     *
+     * __NOTE:__: It is important to note, currently it will call a temporary internal private-sdk
+     * that makes a rest call to get the data requested. When the private SDK has been built
+     * (SFA-518, SFA-670), we can replace the internal sdk solution with private-sdk calls.
+     *
+     * @return accounts - base accounts resource
+     */
+    Accounts getAccounts(String resource);
+}

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/impl/AccountsServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/impl/AccountsServiceImpl.java
@@ -2,11 +2,11 @@ package uk.gov.companieshouse.document.generator.accounts.service.impl;
 
 import static uk.gov.companieshouse.document.generator.accounts.AccountsDocumentInfoServiceImpl.MODULE_NAME_SPACE;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.model.accounts.Accounts;
 import uk.gov.companieshouse.document.generator.accounts.data.accounts.AccountsManager;
+import uk.gov.companieshouse.document.generator.accounts.exception.ServiceException;
 import uk.gov.companieshouse.document.generator.accounts.service.AccountsService;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -16,21 +16,25 @@ public class AccountsServiceImpl implements AccountsService {
 
     private static final Logger LOG = LoggerFactory.getLogger(MODULE_NAME_SPACE);
 
+    @Autowired
+    private AccountsManager accountsManager;
+
     /**
      * {@inheritDoc}
      */
     @Override
-    public Accounts getAccounts(String resource) {
+    public Accounts getAccounts(String resource) throws ServiceException {
         LOG.info("Getting accounts data: " + resource);
 
-        ResponseEntity<Accounts> accounts = AccountsManager.getAccounts(resource);
-
-        if (accounts.getStatusCode() != HttpStatus.OK) {
-            LOG.error("Failed to retrieve data from API: " + resource +
-            "Status Code: " + accounts.getStatusCode().value());
-            return null;
+        Accounts accounts;
+        try {
+            accounts = accountsManager.getAccounts(resource);
+        } catch (Exception e) {
+            LOG.error(e);
+            throw new ServiceException(e.getMessage(), e.getCause());
         }
+
         LOG.trace("Accounts data retrieved successfully: " + resource);
-        return accounts.getBody();
+        return accounts;
     }
 }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/impl/AccountsServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/impl/AccountsServiceImpl.java
@@ -1,0 +1,36 @@
+package uk.gov.companieshouse.document.generator.accounts.service.impl;
+
+import static uk.gov.companieshouse.document.generator.accounts.AccountsDocumentInfoServiceImpl.MODULE_NAME_SPACE;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.model.accounts.Accounts;
+import uk.gov.companieshouse.document.generator.accounts.data.accounts.AccountsManager;
+import uk.gov.companieshouse.document.generator.accounts.service.AccountsService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@Service
+public class AccountsServiceImpl implements AccountsService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MODULE_NAME_SPACE);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Accounts getAccounts(String resource) {
+        LOG.info("Getting accounts data");
+
+        ResponseEntity<Accounts> accounts = AccountsManager.getAccounts(resource);
+
+        if (accounts.getStatusCode() != HttpStatus.OK) {
+            LOG.error("Failed to retrieve data from API: " + resource +
+            "Status Code: " + accounts.getStatusCode().value());
+            return null;
+        }
+        LOG.trace("Accounts data retrieved successfully: " + resource);
+        return accounts.getBody();
+    }
+}

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/impl/AccountsServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/impl/AccountsServiceImpl.java
@@ -24,17 +24,12 @@ public class AccountsServiceImpl implements AccountsService {
      */
     @Override
     public Accounts getAccounts(String resource) throws ServiceException {
-        LOG.info("Getting accounts data: " + resource);
-
-        Accounts accounts;
         try {
-            accounts = accountsManager.getAccounts(resource);
+            LOG.info("Getting accounts data: " + resource);
+            return accountsManager.getAccounts(resource);
         } catch (Exception e) {
             LOG.error(e);
             throw new ServiceException(e.getMessage(), e.getCause());
         }
-
-        LOG.trace("Accounts data retrieved successfully: " + resource);
-        return accounts;
     }
 }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/impl/AccountsServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/impl/AccountsServiceImpl.java
@@ -21,7 +21,7 @@ public class AccountsServiceImpl implements AccountsService {
      */
     @Override
     public Accounts getAccounts(String resource) {
-        LOG.info("Getting accounts data");
+        LOG.info("Getting accounts data: " + resource);
 
         ResponseEntity<Accounts> accounts = AccountsManager.getAccounts(resource);
 

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/service/AccountsServiceImplTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/service/AccountsServiceImplTest.java
@@ -1,0 +1,55 @@
+package uk.gov.companieshouse.document.generator.accounts.service;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.accounts.Accounts;
+import uk.gov.companieshouse.document.generator.accounts.data.accounts.AccountsManager;
+import uk.gov.companieshouse.document.generator.accounts.exception.ServiceException;
+import uk.gov.companieshouse.document.generator.accounts.service.impl.AccountsServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class AccountsServiceImplTest {
+
+    @InjectMocks
+    private AccountsServiceImpl accountsService;
+
+    @Mock
+    private AccountsManager accountsManager;
+
+    @Test
+    @DisplayName("Tests unsuccessful retrieval of accounts that throws exception")
+    void testGetAccountsThrownException() throws Exception {
+        when(accountsManager.getAccounts(anyString())).thenThrow(new Exception());
+
+        assertThrows(ServiceException.class, () -> accountsService.getAccounts("resource"));
+    }
+
+    @Test
+    @DisplayName("Tests unsuccessful retrieval of accounts that returns null")
+    void testGetAccountsReturningNull() throws Exception {
+        when(accountsManager.getAccounts(anyString())).thenReturn(null);
+
+        assertNull(accountsService.getAccounts("resource"));
+    }
+
+    @Test
+    @DisplayName("Tests successful retrieval of accounts")
+    void testGetAccountsSuccess() throws Exception {
+        when(accountsManager.getAccounts(anyString())).thenReturn(new Accounts());
+
+        assertNotNull(accountsService.getAccounts("resource"));
+    }
+}


### PR DESCRIPTION
- adds accounts service layer that interacts with the currently implemented internal `private-sdk`. When the `private-sdk` has been completed, the accounts service layer replaces all references to the internal temporary `private-sdk` solution with the real one.

All refined exception handling and logging will be discussed and designed later on and can be easily added. That is not the scope of this PR. This PR simply deals with the skeleton basic accounts service layer and some basic exception handling and logging.