### PR TITLE
Adds AccountsHandler implementation for base accounts resource

### DIFF
--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountType.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountType.java
@@ -1,0 +1,49 @@
+package uk.gov.companieshouse.document.generator.accounts;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+public enum AccountType {
+    ABRIDGED_ACCOUNTS("accounts", "abridged-accounts", "abridged-accounts", "abridged_accounts");
+
+    private static final String HTML_EXTENSION = ".html";
+    private String assetId;
+    private String templateName;
+    private String enumerationKey;
+    private String resourceKey;
+
+    AccountType(String assetId, String templateName, String enumerationKey, String resourceKey) {
+        this.assetId = assetId;
+        this.templateName = templateName;
+        this.enumerationKey = enumerationKey;
+        this.resourceKey = resourceKey;
+    }
+
+    public String getAssetId() {
+        return assetId;
+    }
+
+    public String getUniqueFileName() {
+        UUID uuid = UUID.randomUUID();
+        return templateName + uuid.toString() + HTML_EXTENSION;
+    }
+
+    public String getTemplateName() {
+        return templateName + HTML_EXTENSION;
+    }
+
+    public String getEnumerationKey() {
+        return enumerationKey;
+    }
+
+    public String getResourceKey() {
+        return resourceKey;
+    }
+
+    public static AccountType getAccountType(String key) {
+        return Arrays.stream(AccountType.values())
+                .filter(e -> e.getResourceKey().equalsIgnoreCase(key))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.model.transaction.Resource;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.document.generator.accounts.exception.HandlerException;
 import uk.gov.companieshouse.document.generator.accounts.handler.accounts.AccountsHandler;
 import uk.gov.companieshouse.document.generator.accounts.service.TransactionService;
 import uk.gov.companieshouse.document.generator.interfaces.DocumentInfoService;
@@ -52,8 +53,12 @@ public class AccountsDocumentInfoServiceImpl implements DocumentInfoService {
 
         // when the Accounts migration has been completed to Company Accounts, this code can be removed
         if (isAccounts(resourceLink)) {
-            return accountsHandler.getAccountsData(resourceLink);
-         }
+            try {
+                return accountsHandler.getAccountsData(resourceLink);
+            } catch (HandlerException e) {
+                LOG.error(e);
+            }
+        }
 
         return null;
     }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/exception/HandlerException.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/exception/HandlerException.java
@@ -1,0 +1,12 @@
+package uk.gov.companieshouse.document.generator.accounts.exception;
+
+public class HandlerException extends Exception {
+
+    public HandlerException(String message) {
+        super(message);
+    }
+
+    public HandlerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/exception/ServiceException.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/exception/ServiceException.java
@@ -2,6 +2,10 @@ package uk.gov.companieshouse.document.generator.accounts.exception;
 
 public class ServiceException extends Exception {
 
+    public ServiceException(String message) {
+        super(message);
+    }
+
     public ServiceException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/AccountsHandler.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/AccountsHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.document.generator.accounts.handler.accounts;
 
+import uk.gov.companieshouse.document.generator.accounts.exception.HandlerException;
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoResponse;
 
 /**
@@ -15,5 +16,5 @@ public interface AccountsHandler {
      * @param resourceLink - resource link
      * @return - document info
      */
-    DocumentInfoResponse getAccountsData(String resourceLink);
+    DocumentInfoResponse getAccountsData(String resourceLink) throws HandlerException;
 }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/AccountsHandlerImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/AccountsHandlerImpl.java
@@ -1,13 +1,55 @@
 package uk.gov.companieshouse.document.generator.accounts.handler.accounts;
 
+import static uk.gov.companieshouse.document.generator.accounts.AccountsDocumentInfoServiceImpl.MODULE_NAME_SPACE;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.model.accounts.Accounts;
+import uk.gov.companieshouse.document.generator.accounts.AccountType;
+import uk.gov.companieshouse.document.generator.accounts.exception.HandlerException;
+import uk.gov.companieshouse.document.generator.accounts.exception.ServiceException;
+import uk.gov.companieshouse.document.generator.accounts.service.AccountsService;
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoResponse;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Component
 public class AccountsHandlerImpl implements AccountsHandler  {
 
+    private static final Logger LOG = LoggerFactory.getLogger(MODULE_NAME_SPACE);
+
+    @Autowired
+    AccountsService accountsService;
+
     @Override
-    public DocumentInfoResponse getAccountsData(String resourceLink) {
+    public DocumentInfoResponse getAccountsData(String resourceLink) throws HandlerException {
+        Accounts accounts;
+
+        try {
+            accounts = accountsService.getAccounts(resourceLink);
+        } catch (ServiceException e) {
+            LOG.error(e);
+            throw new HandlerException(e.getMessage(), e.getCause());
+        }
+
+        // TODO: The accountsType variable shall be used in the implementation of abridged logic
+        AccountType accountsType = getAccountType(accounts);
+
         return new DocumentInfoResponse();
+    }
+
+
+    /**
+     * Get the account type from the account link within links
+     *
+     * @return accountsData - accounts data
+     */
+    private AccountType getAccountType(Accounts accountsData) throws HandlerException {
+        return accountsData.getLinks().keySet()
+                .stream()
+                .filter(e -> !e.equalsIgnoreCase("self"))
+                .map(AccountType::getAccountType)
+                .findFirst()
+                .orElseThrow(() -> new HandlerException("Unable to find account type in account data" + accountsData.getId()));
     }
 }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/AccountsHandlerImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/AccountsHandlerImpl.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.accounts.Accounts;
 import uk.gov.companieshouse.document.generator.accounts.AccountType;
+import uk.gov.companieshouse.document.generator.accounts.LinkType;
 import uk.gov.companieshouse.document.generator.accounts.exception.HandlerException;
 import uk.gov.companieshouse.document.generator.accounts.exception.ServiceException;
 import uk.gov.companieshouse.document.generator.accounts.service.AccountsService;
@@ -47,7 +48,7 @@ public class AccountsHandlerImpl implements AccountsHandler  {
     private AccountType getAccountType(Accounts accountsData) throws HandlerException {
         return accountsData.getLinks().keySet()
                 .stream()
-                .filter(e -> !e.equalsIgnoreCase("self"))
+                .filter(e -> !e.equalsIgnoreCase(LinkType.SELF.getLink()))
                 .map(AccountType::getAccountType)
                 .findFirst()
                 .orElseThrow(() -> new HandlerException("Unable to find account type in account data" + accountsData.getId()));

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/AccountsHandlerImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/AccountsHandlerImpl.java
@@ -29,7 +29,6 @@ public class AccountsHandlerImpl implements AccountsHandler  {
         try {
             accounts = accountsService.getAccounts(resourceLink);
         } catch (ServiceException e) {
-            LOG.error(e);
             throw new HandlerException(e.getMessage(), e.getCause());
         }
 

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImplTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/AccountsDocumentInfoServiceImplTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.model.transaction.Resource;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.document.generator.accounts.exception.HandlerException;
 import uk.gov.companieshouse.document.generator.accounts.handler.accounts.AccountsHandler;
 import uk.gov.companieshouse.document.generator.accounts.service.TransactionService;
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoRequest;
@@ -59,7 +60,7 @@ public class AccountsDocumentInfoServiceImplTest {
 
     @Test
     @DisplayName("Tests the successful retrieval of document data")
-    void testSuccessfulGetDocumentInfo() {
+    void testSuccessfulGetDocumentInfo() throws HandlerException {
         when(transactionService.getTransaction(anyString())).thenReturn(createTransaction());
         when(accountsHandlerMock.getAccountsData(anyString())).thenReturn(new DocumentInfoResponse());
 

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/AccountsHandlerImplTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/AccountsHandlerImplTest.java
@@ -1,16 +1,61 @@
 package uk.gov.companieshouse.document.generator.accounts.handler.accounts;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.accounts.Accounts;
+import uk.gov.companieshouse.document.generator.accounts.exception.HandlerException;
+import uk.gov.companieshouse.document.generator.accounts.exception.ServiceException;
+import uk.gov.companieshouse.document.generator.accounts.service.AccountsService;
 
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
 public class AccountsHandlerImplTest {
+
+    @InjectMocks
+    private AccountsHandlerImpl accountsHandlerImpl;
+
+    @Mock
+    private AccountsService accountsService;
+
+    private static final String ACCOUNTS_RESOURCE_LINK = "/transactions/091174-913515-326060";
+    private static final String ABRIDGED_ACCOUNTS_RESOURCE_LINK = "/transactions/091174-913515-326060/accounts/xU-6Vebn7F8AgLwa2QHBUL2yRpk=";
+
+    @Test
+    @DisplayName("Tests the unsuccessful return of accounts data due to failure in service layer")
+    void testGetAccountsDataFailureFromServiceLayer() throws ServiceException {
+        when(accountsService.getAccounts(anyString())).thenThrow(new ServiceException("Failure in service layer"));
+
+        assertThrows(ServiceException.class, () -> accountsService.getAccounts(anyString()));
+        assertThrows(HandlerException.class, () -> accountsHandlerImpl.getAccountsData(ACCOUNTS_RESOURCE_LINK));
+    }
 
     @Test
     @DisplayName("Tests the successful return of accounts data")
-    void testGetAccountsData() {
-        AccountsHandlerImpl accountsHandler = new AccountsHandlerImpl();
-        assertNotNull(accountsHandler.getAccountsData(""));
+    void testGetAccountsData() throws ServiceException, HandlerException {
+        when(accountsService.getAccounts(anyString())).thenReturn(createAccountsObject());
+        assertNotNull(accountsHandlerImpl.getAccountsData(ACCOUNTS_RESOURCE_LINK));
+    }
+
+    private Accounts createAccountsObject() {
+        Accounts accounts = new Accounts();
+
+        Map<String, String> links = new HashMap<>();
+        links.put("abridged_accounts", ABRIDGED_ACCOUNTS_RESOURCE_LINK);
+        accounts.setLinks(links);
+
+        return accounts;
     }
 }


### PR DESCRIPTION
- adds `ServiceException` constructor accepting just a string error message
- adds `HandlerException` for the handler implementations
- adds `AccountType` enum 
- adds `getAccounts` resource implementation in `AccountsHandler`
- adds and improves unit test coverage around the new scenarios and implementation

NOTE: This PR does not cover the fine tuned Exception handling or logging. It simply puts in place a skeleton in which we can build on afterwards.

Resolves: SFA-567