### PR TITLE
Document Generator Document Type Pattern Matcher

### DIFF
--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/controller/DocumentGeneratorController.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/controller/DocumentGeneratorController.java
@@ -45,7 +45,7 @@ public class DocumentGeneratorController {
 
         if (result.hasErrors()) {
             final Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("resource_uri", documentRequest.getResourceUrl());
+            debugMap.put("resource_uri", documentRequest.getResourceUri());
             debugMap.put("resource_id", documentRequest.getResourceId());
             LOG.debugRequest(request, "error in request body", debugMap);
             return new ResponseEntity<>(result.getAllErrors(), HttpStatus.BAD_REQUEST);

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/models/DocumentRequest.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/models/DocumentRequest.java
@@ -8,8 +8,8 @@ import javax.validation.constraints.NotNull;
 public class DocumentRequest {
 
     @NotNull
-    @JsonProperty("resource_url")
-    private String resourceUrl;
+    @JsonProperty("resource_uri")
+    private String resourceUri;
 
     @NotNull
     @JsonProperty("resource_id")
@@ -22,12 +22,12 @@ public class DocumentRequest {
     @JsonProperty("document_type")
     private String documentType;
 
-    public String getResourceUrl() {
-        return resourceUrl;
+    public String getResourceUri() {
+        return resourceUri;
     }
 
-    public void setResourceUrl(String resourceUrl) {
-        this.resourceUrl = resourceUrl;
+    public void setResourceUri(String resourceUri) {
+        this.resourceUri = resourceUri;
     }
 
     public String getResourceId() {

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/DocumentTypeService.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/DocumentTypeService.java
@@ -1,0 +1,14 @@
+package uk.gov.companieshouse.document.generator.api.service;
+
+import uk.gov.companieshouse.document.generator.api.Exception.DocumentGeneratorServiceException;
+
+public interface DocumentTypeService {
+
+    /**
+     * get Document type by pattern matching the resourceUri to a regex pattern
+     *
+     * @param resourceUri
+     * @return
+     */
+    String getDocumentType(String resourceUri) throws DocumentGeneratorServiceException;
+}

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/DocumentTypeService.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/DocumentTypeService.java
@@ -1,14 +1,15 @@
 package uk.gov.companieshouse.document.generator.api.service;
 
 import uk.gov.companieshouse.document.generator.api.Exception.DocumentGeneratorServiceException;
+import uk.gov.companieshouse.document.generator.api.utility.DocumentType;
 
 public interface DocumentTypeService {
 
     /**
-     * get Document type by pattern matching the resourceUri to a regex pattern
+     * get Document type
      *
      * @param resourceUri
-     * @return
+     * @return String value of document type
      */
-    String getDocumentType(String resourceUri) throws DocumentGeneratorServiceException;
+    DocumentType getDocumentType(String resourceUri) throws DocumentGeneratorServiceException;
 }

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/DocumentTypeService.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/DocumentTypeService.java
@@ -9,7 +9,7 @@ public interface DocumentTypeService {
      * get Document type
      *
      * @param resourceUri
-     * @return String value of document type
+     * @return DocumentType 
      */
     DocumentType getDocumentType(String resourceUri) throws DocumentGeneratorServiceException;
 }

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.document.generator.api.service.impl;
 
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.document.generator.api.Exception.DocumentGeneratorServiceException;
@@ -9,6 +10,7 @@ import uk.gov.companieshouse.document.generator.api.document.render.models.Rende
 import uk.gov.companieshouse.document.generator.api.models.DocumentRequest;
 import uk.gov.companieshouse.document.generator.api.models.DocumentResponse;
 import uk.gov.companieshouse.document.generator.api.service.DocumentGeneratorService;
+import uk.gov.companieshouse.document.generator.api.service.DocumentTypeService;
 import uk.gov.companieshouse.document.generator.api.service.response.ResponseObject;
 import uk.gov.companieshouse.document.generator.api.service.response.ResponseStatus;
 import uk.gov.companieshouse.document.generator.interfaces.DocumentInfoService;
@@ -33,6 +35,9 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
 
     private RenderDocumentRequestHandler requestHandler;
 
+    @Autowired
+    private DocumentTypeService documentTypeService;
+
     private static final String DOCUMENT_RENDER_SERVICE_HOST_ENV_VAR = "DOCUMENT_RENDER_SERVICE_HOST";
 
     private static final String CONTEXT_PATH = "/document-render/store?is_public=true";
@@ -41,10 +46,11 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
 
     @Autowired
     public DocumentGeneratorServiceImpl(DocumentInfoService documentInfoService, EnvironmentReader environmentReader,
-                                        RenderDocumentRequestHandler requestHandler) {
+                                        RenderDocumentRequestHandler requestHandler, DocumentTypeService documentTypeService) {
         this.documentInfoService = documentInfoService;
         this.environmentReader = environmentReader;
         this.requestHandler = requestHandler;
+        this.documentTypeService = documentTypeService;
     }
 
     @Override
@@ -53,13 +59,21 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
         DocumentResponse response;
 
         final Map < String, Object > debugMap = new HashMap < > ();
-        debugMap.put("resource_uri", documentRequest.getResourceUrl());
+        debugMap.put("resource_uri", documentRequest.getResourceUri());
         debugMap.put("resource_id", documentRequest.getResourceId());
 
-        //TODO addition of get doc gen type from URL to be added in SFA 580
+        try {
+            //TODO implement the use of DocumentType SFA 719
+            String DocumentType = documentTypeService.getDocumentType(documentRequest.getResourceUri());
+        } catch (DocumentGeneratorServiceException dgse){
+            LOG.errorContext(requestId, dgse, debugMap);
+            return new ResponseObject(ResponseStatus.NO_DOCUMENT_TYPE_FOUND, null);
+        }
 
         //TODO currently no impl present, being completed in SFA 567
         DocumentInfoRequest documentInfoRequest = new DocumentInfoRequest();
+        BeanUtils.copyProperties(documentInfoRequest, documentRequest);
+
         DocumentInfoResponse documentInfoResponse = documentInfoService.getDocumentInfo(documentInfoRequest);
 
         if (documentInfoResponse != null) {

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
@@ -35,7 +35,6 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
 
     private RenderDocumentRequestHandler requestHandler;
 
-    @Autowired
     private DocumentTypeService documentTypeService;
 
     private static final String DOCUMENT_RENDER_SERVICE_HOST_ENV_VAR = "DOCUMENT_RENDER_SERVICE_HOST";

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.document.generator.api.service.DocumentGeneratorSer
 import uk.gov.companieshouse.document.generator.api.service.DocumentTypeService;
 import uk.gov.companieshouse.document.generator.api.service.response.ResponseObject;
 import uk.gov.companieshouse.document.generator.api.service.response.ResponseStatus;
+import uk.gov.companieshouse.document.generator.api.utility.DocumentType;
 import uk.gov.companieshouse.document.generator.interfaces.DocumentInfoService;
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoRequest;
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoResponse;
@@ -63,10 +64,10 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
 
         try {
             //TODO implement the use of DocumentType SFA 719
-            String DocumentType = documentTypeService.getDocumentType(documentRequest.getResourceUri());
+            DocumentType DocumentType = documentTypeService.getDocumentType(documentRequest.getResourceUri());
         } catch (DocumentGeneratorServiceException dgse){
             LOG.errorContext(requestId, dgse, debugMap);
-            return new ResponseObject(ResponseStatus.NO_DOCUMENT_TYPE_FOUND, null);
+            return new ResponseObject(ResponseStatus.NO_TYPE_FOUND, null);
         }
 
         //TODO currently no impl present, being completed in SFA 567
@@ -86,7 +87,7 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
                 LOG.errorContext(requestId, documentGeneratorServiceException, debugMap);
 
                 response = setDocumentResponse(renderResponse, documentInfoResponse);
-                return new ResponseObject(ResponseStatus.DOCUMENT_NOT_RENDERED, response);
+                return new ResponseObject(ResponseStatus.NOT_RENDERED, response);
             }
 
             response = setDocumentResponse(renderResponse, documentInfoResponse);

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentTypeServiceImpl.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentTypeServiceImpl.java
@@ -2,21 +2,17 @@ package uk.gov.companieshouse.document.generator.api.service.impl;
 
 import uk.gov.companieshouse.document.generator.api.Exception.DocumentGeneratorServiceException;
 import uk.gov.companieshouse.document.generator.api.service.DocumentTypeService;
+import uk.gov.companieshouse.document.generator.api.utility.DocumentType;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Arrays;
 
 public class DocumentTypeServiceImpl implements DocumentTypeService {
 
     @Override
-    public String getDocumentType(String resourceUri) throws DocumentGeneratorServiceException {
+    public DocumentType getDocumentType(String resourceUri) throws DocumentGeneratorServiceException {
 
-        Map<String, String> docType = new HashMap<>();
-        docType.put("ACCOUNTS", "/transactions\\/.*\\/(?:company-)?accounts\\/.*");
-
-        return docType.entrySet().stream()
-                .filter(docTypeEntry -> resourceUri.matches(docTypeEntry.getValue()))
-                .map(docTypeEntry -> docTypeEntry.getKey())
+        return Arrays.stream(DocumentType.values())
+                .filter(docTypeEntry -> resourceUri.matches(docTypeEntry.getPattern()))
                 .findFirst().orElseThrow(() -> new DocumentGeneratorServiceException(
                         "Could not locate the document type from the Uri"));
     }

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentTypeServiceImpl.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentTypeServiceImpl.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.document.generator.api.service.impl;
+
+import uk.gov.companieshouse.document.generator.api.Exception.DocumentGeneratorServiceException;
+import uk.gov.companieshouse.document.generator.api.service.DocumentTypeService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DocumentTypeServiceImpl implements DocumentTypeService {
+
+    @Override
+    public String getDocumentType(String resourceUri) throws DocumentGeneratorServiceException {
+
+        Map<String, String> docType = new HashMap<>();
+        docType.put("ACCOUNTS", "/transactions\\/.*\\/(?:company-)?accounts\\/.*");
+
+        return docType.entrySet().stream()
+                .filter(docTypeEntry -> resourceUri.matches(docTypeEntry.getValue()))
+                .map(docTypeEntry -> docTypeEntry.getKey())
+                .findFirst().orElseThrow(() -> new DocumentGeneratorServiceException(
+                        "Could not locate the document type from the Uri"));
+    }
+}

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/response/ResponseObject.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/response/ResponseObject.java
@@ -30,7 +30,7 @@ public class ResponseObject  {
         return documentResponse;
     }
 
-    public void setData(DocumentResponse data) {
+    public void setData(DocumentResponse documentResponse) {
         this.documentResponse = documentResponse;
     }
 

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/response/ResponseStatus.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/response/ResponseStatus.java
@@ -4,5 +4,6 @@ public enum ResponseStatus {
 
     CREATED,
     NO_DATA_RETRIEVED,
-    DOCUMENT_NOT_RENDERED
+    DOCUMENT_NOT_RENDERED,
+    NO_DOCUMENT_TYPE_FOUND
 }

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/response/ResponseStatus.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/response/ResponseStatus.java
@@ -4,6 +4,6 @@ public enum ResponseStatus {
 
     CREATED,
     NO_DATA_RETRIEVED,
-    DOCUMENT_NOT_RENDERED,
-    NO_DOCUMENT_TYPE_FOUND
+    NOT_RENDERED,
+    NO_TYPE_FOUND
 }

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/utility/ApiResponseMapper.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/utility/ApiResponseMapper.java
@@ -14,11 +14,12 @@ public class ApiResponseMapper {
             case CREATED:
                 return ResponseEntity.status(HttpStatus.CREATED).body(responseObject.getData());
             case NO_DATA_RETRIEVED:
+            case NO_DOCUMENT_TYPE_FOUND:
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
             case DOCUMENT_NOT_RENDERED:
                 return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(responseObject.getData());
-               default:
-                   return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+            default:
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
 }

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/utility/ApiResponseMapper.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/utility/ApiResponseMapper.java
@@ -14,9 +14,9 @@ public class ApiResponseMapper {
             case CREATED:
                 return ResponseEntity.status(HttpStatus.CREATED).body(responseObject.getData());
             case NO_DATA_RETRIEVED:
-            case NO_DOCUMENT_TYPE_FOUND:
+            case NO_TYPE_FOUND:
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
-            case DOCUMENT_NOT_RENDERED:
+            case NOT_RENDERED:
                 return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(responseObject.getData());
             default:
                 return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/utility/DocumentType.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/utility/DocumentType.java
@@ -1,0 +1,16 @@
+package uk.gov.companieshouse.document.generator.api.utility;
+
+public enum DocumentType {
+
+    ACCOUNTS("/transactions\\/.*\\/(?:company-)?accounts\\/.*");
+
+    private String pattern;
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    DocumentType(String pattern) {
+        this.pattern = pattern;
+    }
+}

--- a/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/controller/DocumentGeneratorControllerTest.java
+++ b/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/controller/DocumentGeneratorControllerTest.java
@@ -142,6 +142,24 @@ public class DocumentGeneratorControllerTest {
         assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode());
     }
 
+    @Test
+    @DisplayName("Tests fails to obtain documentType")
+    public void testsFailedToObtainDocumentType() {
+
+        DocumentRequest request = setDocumentgeneratorRequest();
+
+        ResponseObject responseObject = new ResponseObject(ResponseStatus.NO_DOCUMENT_TYPE_FOUND);
+
+        when(mockBindingResult.hasErrors()).thenReturn(false);
+        when(mockDocumentGeneratorService.generate(any(DocumentRequest.class), any(String.class))).thenReturn(responseObject);
+        when(mockApiResponseMapper.map(any(ResponseObject.class))).thenReturn(ResponseEntity.status(HttpStatus.BAD_REQUEST).build());
+
+        ResponseEntity responseEntity = documentGeneratorController.generateDocument(request, mockBindingResult, mockHttpServletRequest);
+
+        assertNotNull(responseEntity);
+        assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode());
+    }
+
     /**
      * Set the data for the document generator request
      *
@@ -153,7 +171,7 @@ public class DocumentGeneratorControllerTest {
         request.setDocumentType("documentType");
         request.setMimeType("mimeType");
         request.setResourceId("resourceId");
-        request.setResourceUrl("resourceUrl");
+        request.setResourceUri("resourceUri");
 
         return request;
     }

--- a/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/controller/DocumentGeneratorControllerTest.java
+++ b/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/controller/DocumentGeneratorControllerTest.java
@@ -112,7 +112,7 @@ public class DocumentGeneratorControllerTest {
         response.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
         response.setDescriptionValues(setDescriptionValue());
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.DOCUMENT_NOT_RENDERED, response);
+        ResponseObject responseObject = new ResponseObject(ResponseStatus.NOT_RENDERED, response);
 
         when(mockBindingResult.hasErrors()).thenReturn(false);
         when(mockDocumentGeneratorService.generate(any(DocumentRequest.class), any(String.class))).thenReturn(responseObject);
@@ -148,7 +148,7 @@ public class DocumentGeneratorControllerTest {
 
         DocumentRequest request = setDocumentgeneratorRequest();
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.NO_DOCUMENT_TYPE_FOUND);
+        ResponseObject responseObject = new ResponseObject(ResponseStatus.NO_TYPE_FOUND);
 
         when(mockBindingResult.hasErrors()).thenReturn(false);
         when(mockDocumentGeneratorService.generate(any(DocumentRequest.class), any(String.class))).thenReturn(responseObject);

--- a/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentGeneratorServiceTest.java
+++ b/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentGeneratorServiceTest.java
@@ -15,6 +15,7 @@ import uk.gov.companieshouse.document.generator.api.models.DocumentRequest;
 import uk.gov.companieshouse.document.generator.api.service.impl.DocumentGeneratorServiceImpl;
 import uk.gov.companieshouse.document.generator.api.service.response.ResponseObject;
 import uk.gov.companieshouse.document.generator.api.service.response.ResponseStatus;
+import uk.gov.companieshouse.document.generator.api.utility.DocumentType;
 import uk.gov.companieshouse.document.generator.interfaces.DocumentInfoService;
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoRequest;
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoResponse;
@@ -72,7 +73,7 @@ public class DocumentGeneratorServiceTest {
     @DisplayName("Test a successful generate completed")
     public void testsSuccessfulGenerateCompleted() throws IOException, DocumentGeneratorServiceException {
 
-        when(mockDocumentTypeService.getDocumentType(any(String.class))).thenReturn("ACCOUNTS");
+        when(mockDocumentTypeService.getDocumentType(any(String.class))).thenReturn(DocumentType.ACCOUNTS);
         when(mockDocumentInfoService.getDocumentInfo(any(DocumentInfoRequest.class))).thenReturn(setSuccessfulDocumentInfo());
         when(mockRequestHandler.sendDataToDocumentRenderService(any(String.class), any(RenderDocumentRequest.class))).thenReturn(setSuccessfulRenderResponse());
 
@@ -93,7 +94,7 @@ public class DocumentGeneratorServiceTest {
     @DisplayName("Tests when null returned from documentInfoService")
     public void testsWhenErrorThrownFromDocumentInfoService() throws DocumentGeneratorServiceException {
 
-        when(mockDocumentTypeService.getDocumentType(any(String.class))).thenReturn("ACCOUNTS");
+        when(mockDocumentTypeService.getDocumentType(any(String.class))).thenReturn(DocumentType.ACCOUNTS);
         when(mockDocumentInfoService.getDocumentInfo(any(DocumentInfoRequest.class))).thenReturn(null);
 
         ResponseObject response = documentGeneratorService.generate(setValidRequest(), REQUEST_ID);
@@ -111,14 +112,14 @@ public class DocumentGeneratorServiceTest {
         ResponseObject response = documentGeneratorService.generate(setValidRequest(), REQUEST_ID);
 
         assertNull(response.getData());
-        assertEquals(ResponseStatus.NO_DOCUMENT_TYPE_FOUND, response.getStatus());
+        assertEquals(ResponseStatus.NO_TYPE_FOUND, response.getStatus());
     }
 
     @Test
     @DisplayName("Tests when an error thrown from requestHandler")
     public void testsWhenErrorThrownFromRequestHandler() throws IOException, DocumentGeneratorServiceException {
 
-        when(mockDocumentTypeService.getDocumentType(any(String.class))).thenReturn("ACCOUNTS");
+        when(mockDocumentTypeService.getDocumentType(any(String.class))).thenReturn(DocumentType.ACCOUNTS);
         when(mockDocumentInfoService.getDocumentInfo(any(DocumentInfoRequest.class))).thenReturn(setSuccessfulDocumentInfo());
         when(mockRequestHandler.sendDataToDocumentRenderService(any(String.class), any(RenderDocumentRequest.class))).thenThrow(IOException.class);
 
@@ -132,7 +133,7 @@ public class DocumentGeneratorServiceTest {
         assertEquals(DESCRIPTION, response.getData().getDescription());
         assertEquals(DESCRIPTION_IDENTIFIER, response.getData().getDescriptionIdentifier());
 
-        assertEquals(ResponseStatus.DOCUMENT_NOT_RENDERED, response.getStatus());
+        assertEquals(ResponseStatus.NOT_RENDERED, response.getStatus());
     }
 
     /**

--- a/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentTypeServiceTest.java
+++ b/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentTypeServiceTest.java
@@ -1,0 +1,44 @@
+package uk.gov.companieshouse.document.generator.api.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.document.generator.api.Exception.DocumentGeneratorServiceException;
+import uk.gov.companieshouse.document.generator.api.service.impl.DocumentTypeServiceImpl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DocumentTypeServiceTest {
+
+    private DocumentTypeService documentTypeService;
+
+    @BeforeEach
+    public void setUp() {
+        documentTypeService = new DocumentTypeServiceImpl();
+    }
+
+    @Test
+    @DisplayName("tests that a string containing 'ACCOUNTS' is returned")
+    public void testSuccessfulPatternMatchToAccountsReturned() throws DocumentGeneratorServiceException {
+
+        String testValidAccountUri = "/transactions/111111-222222-333333/accounts/Abc1Defg2hiJkLmNoP34QR5sT6u=";
+        String result = documentTypeService.getDocumentType(testValidAccountUri);
+
+        assertEquals("ACCOUNTS", result);
+    }
+
+    @Test
+    @DisplayName("tests that an error returned when incorrect Uri input")
+    public void testErrorReturnedWhenUriDoesNotMatchPattern() throws DocumentGeneratorServiceException {
+
+        String testInvalidAccountUri = "/transactions";
+
+        assertThrows(DocumentGeneratorServiceException.class, () -> documentTypeService.getDocumentType(testInvalidAccountUri));
+    }
+}

--- a/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentTypeServiceTest.java
+++ b/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentTypeServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.document.generator.api.Exception.DocumentGeneratorServiceException;
 import uk.gov.companieshouse.document.generator.api.service.impl.DocumentTypeServiceImpl;
+import uk.gov.companieshouse.document.generator.api.utility.DocumentType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -24,18 +25,28 @@ public class DocumentTypeServiceTest {
     }
 
     @Test
-    @DisplayName("tests that a string containing 'ACCOUNTS' is returned")
-    public void testSuccessfulPatternMatchToAccountsReturned() throws DocumentGeneratorServiceException {
+    @DisplayName("tests that a DocumentType containing 'ACCOUNTS' is returned when uri contains 'accounts'")
+    public void testSuccessfulPatternMatchToAccountsReturnedForAccounts() throws DocumentGeneratorServiceException {
 
         String testValidAccountUri = "/transactions/111111-222222-333333/accounts/Abc1Defg2hiJkLmNoP34QR5sT6u=";
-        String result = documentTypeService.getDocumentType(testValidAccountUri);
+        DocumentType result = documentTypeService.getDocumentType(testValidAccountUri);
 
-        assertEquals("ACCOUNTS", result);
+        assertEquals(DocumentType.ACCOUNTS, result);
+    }
+
+    @Test
+    @DisplayName("tests that a DocumentType containing 'ACCOUNTS' is returned when uri contains 'company-accounts'")
+    public void testSuccessfulPatternMatchToAccountsReturnedForCompanyAccounts() throws DocumentGeneratorServiceException {
+
+        String testValidAccountUri = "/transactions/111111-222222-333333/company-accounts/Abc1Defg2hiJkLmNoP34QR5sT6u=";
+        DocumentType result = documentTypeService.getDocumentType(testValidAccountUri);
+
+        assertEquals(DocumentType.ACCOUNTS, result);
     }
 
     @Test
     @DisplayName("tests that an error returned when incorrect Uri input")
-    public void testErrorReturnedWhenUriDoesNotMatchPattern() throws DocumentGeneratorServiceException {
+    public void testErrorReturnedWhenUriDoesNotMatchPattern() {
 
         String testInvalidAccountUri = "/transactions";
 

--- a/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentTypeServiceTest.java
+++ b/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentTypeServiceTest.java
@@ -19,6 +19,12 @@ public class DocumentTypeServiceTest {
 
     private DocumentTypeService documentTypeService;
 
+    private static final String TRANSACTIONS_URI = "/transactions/111111-222222-333333";
+
+    private static final String COMPANY_ACCOUNTS_URI = "/company-accounts/Abc1Defg2hiJkLmNoP34QR5sT6u=";
+
+    private static final String ACCOUNTS_URI = "/accounts/Abc1Defg2hiJkLmNoP34QR5sT6u=";
+
     @BeforeEach
     public void setUp() {
         documentTypeService = new DocumentTypeServiceImpl();
@@ -28,7 +34,7 @@ public class DocumentTypeServiceTest {
     @DisplayName("tests that a DocumentType containing 'ACCOUNTS' is returned when uri contains 'accounts'")
     public void testSuccessfulPatternMatchToAccountsReturnedForAccounts() throws DocumentGeneratorServiceException {
 
-        String testValidAccountUri = "/transactions/111111-222222-333333/accounts/Abc1Defg2hiJkLmNoP34QR5sT6u=";
+        String testValidAccountUri = TRANSACTIONS_URI + ACCOUNTS_URI;
         DocumentType result = documentTypeService.getDocumentType(testValidAccountUri);
 
         assertEquals(DocumentType.ACCOUNTS, result);
@@ -38,7 +44,7 @@ public class DocumentTypeServiceTest {
     @DisplayName("tests that a DocumentType containing 'ACCOUNTS' is returned when uri contains 'company-accounts'")
     public void testSuccessfulPatternMatchToAccountsReturnedForCompanyAccounts() throws DocumentGeneratorServiceException {
 
-        String testValidAccountUri = "/transactions/111111-222222-333333/company-accounts/Abc1Defg2hiJkLmNoP34QR5sT6u=";
+        String testValidAccountUri = TRANSACTIONS_URI + COMPANY_ACCOUNTS_URI;
         DocumentType result = documentTypeService.getDocumentType(testValidAccountUri);
 
         assertEquals(DocumentType.ACCOUNTS, result);
@@ -48,7 +54,7 @@ public class DocumentTypeServiceTest {
     @DisplayName("tests that an error returned when incorrect Uri input")
     public void testErrorReturnedWhenUriDoesNotMatchPattern() {
 
-        String testInvalidAccountUri = "/transactions";
+        String testInvalidAccountUri = TRANSACTIONS_URI;
 
         assertThrows(DocumentGeneratorServiceException.class, () -> documentTypeService.getDocumentType(testInvalidAccountUri));
     }

--- a/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/utility/ApiResponseMapperTest.java
+++ b/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/utility/ApiResponseMapperTest.java
@@ -84,7 +84,7 @@ public class ApiResponseMapperTest {
         documentResponse.setDescription(DESCRIPTION);
         documentResponse.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
 
-        ResponseObject responseObject = new ResponseObject(ResponseStatus.DOCUMENT_NOT_RENDERED, documentResponse);
+        ResponseObject responseObject = new ResponseObject(ResponseStatus.NOT_RENDERED, documentResponse);
 
         ResponseEntity responseEntity = apiResponseMapper.map(responseObject);
 


### PR DESCRIPTION
New service created to deal with pattern matching the resourceUri to a specific documentType

- Created new service called DocumentTypeService to pattern match the resourceUri to obtain documentType.
- Created JUnit tests for new service.
- Updated existing tests to include new service.
- Added new service to documentGeneratorService to populate the documentType String.
- Updated resourceUrl to be resourceUri.

Resolves SFA 580