### PR TITLE
Document Generator creation of DocumentInfoServiceFactor

### DIFF
--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/DocumentGeneratorApplicationConfiguration.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/DocumentGeneratorApplicationConfiguration.java
@@ -1,10 +1,14 @@
 package uk.gov.companieshouse.document.generator.api;
 
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.beans.factory.config.ServiceLocatorFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 import uk.gov.companieshouse.document.generator.accounts.AccountsDocumentInfoServiceImpl;
-import uk.gov.companieshouse.document.generator.interfaces.DocumentInfoService;
+import uk.gov.companieshouse.document.generator.api.factory.DocumentInfoServiceFactory;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
 
@@ -13,12 +17,20 @@ import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
 public class DocumentGeneratorApplicationConfiguration {
 
     @Bean
-    EnvironmentReader environmentReader() {
-        return new EnvironmentReaderImpl();
+    public FactoryBean serviceLocatorFactoryBean() {
+        ServiceLocatorFactoryBean factoryBean = new ServiceLocatorFactoryBean();
+        factoryBean.setServiceLocatorInterface(DocumentInfoServiceFactory.class);
+        return factoryBean;
+    }
+
+    @Bean(name = "ACCOUNTS")
+    @Scope(scopeName = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public AccountsDocumentInfoServiceImpl accountsDocumentInfoService() {
+        return new AccountsDocumentInfoServiceImpl();
     }
 
     @Bean
-    DocumentInfoService documentInfoService() {
-        return new AccountsDocumentInfoServiceImpl();
+    EnvironmentReader environmentReader() {
+        return new EnvironmentReaderImpl();
     }
 }

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/factory/DocumentInfoServiceFactory.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/factory/DocumentInfoServiceFactory.java
@@ -1,0 +1,14 @@
+package uk.gov.companieshouse.document.generator.api.factory;
+
+import uk.gov.companieshouse.document.generator.interfaces.DocumentInfoService;
+
+public interface DocumentInfoServiceFactory {
+
+    /**
+     * Factory interface to select Implementation to use when generating a document
+     *
+     * @param documentType The type of document being generated
+     * @return DocumentInfoService the correct implementation of the service
+     */
+    DocumentInfoService get(String documentType);
+}

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/utility/DocumentType.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/utility/DocumentType.java
@@ -13,4 +13,9 @@ public enum DocumentType {
     DocumentType(String pattern) {
         this.pattern = pattern;
     }
+
+    @Override
+    public String toString() {
+        return this.name();
+    }
 }

--- a/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentGeneratorServiceTest.java
+++ b/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentGeneratorServiceTest.java
@@ -1,14 +1,5 @@
 package uk.gov.companieshouse.document.generator.api.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,10 +7,11 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.document.generator.api.exception.DocumentGeneratorServiceException;
 import uk.gov.companieshouse.document.generator.api.document.render.RenderDocumentRequestHandler;
 import uk.gov.companieshouse.document.generator.api.document.render.models.RenderDocumentRequest;
 import uk.gov.companieshouse.document.generator.api.document.render.models.RenderDocumentResponse;
+import uk.gov.companieshouse.document.generator.api.exception.DocumentGeneratorServiceException;
+import uk.gov.companieshouse.document.generator.api.factory.DocumentInfoServiceFactory;
 import uk.gov.companieshouse.document.generator.api.models.DocumentRequest;
 import uk.gov.companieshouse.document.generator.api.service.impl.DocumentGeneratorServiceImpl;
 import uk.gov.companieshouse.document.generator.api.service.response.ResponseObject;
@@ -30,12 +22,25 @@ import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoReq
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoResponse;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class DocumentGeneratorServiceTest {
 
     @Mock
     private DocumentInfoService mockDocumentInfoService;
+
+    @Mock
+    private DocumentInfoServiceFactory mockDocumentInfoServiceFactory;
 
     @Mock
     private RenderDocumentRequestHandler mockRequestHandler;
@@ -64,8 +69,8 @@ public class DocumentGeneratorServiceTest {
 
     @BeforeEach
     public void setUp() {
-        documentGeneratorService = new DocumentGeneratorServiceImpl(mockDocumentInfoService,
-                mockEnvironmentReader, mockRequestHandler, mockDocumentTypeService);
+        documentGeneratorService = new DocumentGeneratorServiceImpl(mockDocumentInfoServiceFactory, mockEnvironmentReader,
+                mockRequestHandler, mockDocumentTypeService);
     }
 
     @Test
@@ -73,6 +78,7 @@ public class DocumentGeneratorServiceTest {
     public void testsSuccessfulGenerateCompleted() throws IOException, DocumentGeneratorServiceException {
 
         when(mockDocumentTypeService.getDocumentType(any(String.class))).thenReturn(DocumentType.ACCOUNTS);
+        when(mockDocumentInfoServiceFactory.get(any(String.class))).thenReturn(mockDocumentInfoService);
         when(mockDocumentInfoService.getDocumentInfo(any(DocumentInfoRequest.class))).thenReturn(setSuccessfulDocumentInfo());
         when(mockRequestHandler.sendDataToDocumentRenderService(any(String.class), any(RenderDocumentRequest.class))).thenReturn(setSuccessfulRenderResponse());
 
@@ -94,6 +100,7 @@ public class DocumentGeneratorServiceTest {
     public void testsWhenErrorThrownFromDocumentInfoService() throws DocumentGeneratorServiceException {
 
         when(mockDocumentTypeService.getDocumentType(any(String.class))).thenReturn(DocumentType.ACCOUNTS);
+        when(mockDocumentInfoServiceFactory.get(any(String.class))).thenReturn(mockDocumentInfoService);
         when(mockDocumentInfoService.getDocumentInfo(any(DocumentInfoRequest.class))).thenReturn(null);
 
         ResponseObject response = documentGeneratorService.generate(setValidRequest(), REQUEST_ID);
@@ -119,6 +126,7 @@ public class DocumentGeneratorServiceTest {
     public void testsWhenErrorThrownFromRequestHandler() throws IOException, DocumentGeneratorServiceException {
 
         when(mockDocumentTypeService.getDocumentType(any(String.class))).thenReturn(DocumentType.ACCOUNTS);
+        when(mockDocumentInfoServiceFactory.get(any(String.class))).thenReturn(mockDocumentInfoService);
         when(mockDocumentInfoService.getDocumentInfo(any(DocumentInfoRequest.class))).thenReturn(setSuccessfulDocumentInfo());
         when(mockRequestHandler.sendDataToDocumentRenderService(any(String.class), any(RenderDocumentRequest.class))).thenThrow(IOException.class);
 


### PR DESCRIPTION
New interface created called DocumentInfoServiceFactory to control which implementation is used by passing in the documentType parameter that is obtained through the resourceUri.

- Added factory package with interface called DocumentInfoServiceFactory
- Updated ApplicationConfig to include new bean for ACCOUNTS impl and serviceLocatorFactoryBean
- Corrected copyproperties as source and target wrong way round
- Updated DocumentType to include a toString to obtain the name
- Updated DocumentGeneratorServiceImpl to make correct call to service using the new factory

Resolves SFA 719