### PR TITLE
document generator set location document to be stored

### DIFF
--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
@@ -129,7 +129,7 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
             throws IOException {
 
         String host = environmentReader.getMandatoryString(DOCUMENT_RENDER_SERVICE_HOST_ENV_VAR);
-        String url = host + CONTEXT_PATH;
+        String url = new StringBuilder(host).append(CONTEXT_PATH).toString();
 
         RenderDocumentRequest requestData = new RenderDocumentRequest();
         requestData.setAssetId(documentInfoResponse.getAssetId());
@@ -137,7 +137,7 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
         requestData.setData(documentInfoResponse.getData());
         requestData.setDocumentType(documentRequest.getMimeType());
         requestData.setTemplateName(documentInfoResponse.getTemplateName());
-        requestData.setLocation(setLocation(documentInfoResponse.getPath()));
+        requestData.setLocation(buildLocation(documentInfoResponse.getPath()));
 
         return requestHandler.sendDataToDocumentRenderService(url, requestData);
     }
@@ -148,12 +148,11 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
      * @param path the path to be added
      * @return location the full location path
      */
-    private String setLocation(String path) {
+    private String buildLocation(String path) {
 
         String bucketName = environmentReader.getMandatoryString(DOCUMENT_BUCKET_NAME_ENV_VAR);
-        String location = S3 + bucketName + path;
 
-        return location;
+        return new StringBuilder(S3).append(bucketName).append(path).toString();
     }
 
     /**

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
@@ -143,10 +143,10 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
     }
 
     /**
-     * Set the location the document the document is to be stored at
+     * build the location the document is to be stored at
      *
      * @param path the path to be added
-     * @return location the full location path
+     * @return String the full location path constructed with StringBuilder
      */
     private String buildLocation(String path) {
 

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
@@ -40,6 +40,10 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
 
     private static final String DOCUMENT_RENDER_SERVICE_HOST_ENV_VAR = "DOCUMENT_RENDER_SERVICE_HOST";
 
+    private static final String DOCUMENT_BUCKET_NAME_ENV_VAR = "DOCUMENT_BUCKET_NAME";
+
+    private static final String S3 = "s3://";
+
     private static final String CONTEXT_PATH = "/document-render/store?is_public=true";
 
     private static final Logger LOG = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
@@ -133,9 +137,23 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
         requestData.setData(documentInfoResponse.getData());
         requestData.setDocumentType(documentRequest.getMimeType());
         requestData.setTemplateName(documentInfoResponse.getTemplateName());
-        requestData.setLocation(documentInfoResponse.getPath());
+        requestData.setLocation(setLocation(documentInfoResponse.getPath()));
 
         return requestHandler.sendDataToDocumentRenderService(url, requestData);
+    }
+
+    /**
+     * Set the location the document the document is to be stored at
+     *
+     * @param path the path to be added
+     * @return location the full location path
+     */
+    private String setLocation(String path) {
+
+        String bucketName = environmentReader.getMandatoryString(DOCUMENT_BUCKET_NAME_ENV_VAR);
+        String location = S3 + bucketName + path;
+
+        return location;
     }
 
     /**

--- a/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentGeneratorServiceTest.java
+++ b/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentGeneratorServiceTest.java
@@ -182,7 +182,7 @@ public class DocumentGeneratorServiceTest {
     /**
      * Build the string path for parameter location
      *
-     * @return location as a string value
+     * @return String the Location as a string value
      */
     private String buildLocation() {
 

--- a/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentGeneratorServiceTest.java
+++ b/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentGeneratorServiceTest.java
@@ -63,9 +63,9 @@ public class DocumentGeneratorServiceTest {
 
     private String PATH = "/assetId/UniqueFileName";
 
-    private String LOCATION = "s3://bucket_location/assetId/UniqueFileName";
-
     private String BUCKET_LOCATION = "bucket_location";
+
+    private String S3 = "s3://";
 
     private String DATE = "date";
 
@@ -95,7 +95,7 @@ public class DocumentGeneratorServiceTest {
         assertEquals(DESCRIPTION, response.getData().getDescription());
         assertEquals(DESCRIPTION_IDENTIFIER, response.getData().getDescriptionIdentifier());
         assertEquals(SIZE, response.getData().getSize());
-        assertEquals(LOCATION, response.getData().getLinks());
+        assertEquals(buildLocation(), response.getData().getLinks());
 
         assertEquals(ResponseStatus.CREATED, response.getStatus());
     }
@@ -174,9 +174,19 @@ public class DocumentGeneratorServiceTest {
 
         RenderDocumentResponse renderDocumentResponse = new RenderDocumentResponse();
         renderDocumentResponse.setDocumentSize(SIZE);
-        renderDocumentResponse.setLocation(LOCATION);
+        renderDocumentResponse.setLocation(buildLocation());
 
         return renderDocumentResponse;
+    }
+
+    /**
+     * Build the string path for parameter location
+     *
+     * @return location as a string value
+     */
+    private String buildLocation() {
+
+        return new StringBuilder(S3).append(BUCKET_LOCATION).append(PATH).toString();
     }
 
     /**

--- a/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentGeneratorServiceTest.java
+++ b/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentGeneratorServiceTest.java
@@ -61,7 +61,11 @@ public class DocumentGeneratorServiceTest {
 
     private String SIZE = "size";
 
-    private String LOCATION = "location.file";
+    private String PATH = "/assetId/UniqueFileName";
+
+    private String LOCATION = "s3://bucket_location/assetId/UniqueFileName";
+
+    private String BUCKET_LOCATION = "bucket_location";
 
     private String DATE = "date";
 
@@ -81,6 +85,7 @@ public class DocumentGeneratorServiceTest {
         when(mockDocumentInfoServiceFactory.get(any(String.class))).thenReturn(mockDocumentInfoService);
         when(mockDocumentInfoService.getDocumentInfo(any(DocumentInfoRequest.class))).thenReturn(setSuccessfulDocumentInfo());
         when(mockRequestHandler.sendDataToDocumentRenderService(any(String.class), any(RenderDocumentRequest.class))).thenReturn(setSuccessfulRenderResponse());
+        when(mockEnvironmentReader.getMandatoryString(any(String.class))).thenReturn(BUCKET_LOCATION);
 
         ResponseObject response = documentGeneratorService.generate(setValidRequest(), REQUEST_ID);
 
@@ -129,6 +134,7 @@ public class DocumentGeneratorServiceTest {
         when(mockDocumentInfoServiceFactory.get(any(String.class))).thenReturn(mockDocumentInfoService);
         when(mockDocumentInfoService.getDocumentInfo(any(DocumentInfoRequest.class))).thenReturn(setSuccessfulDocumentInfo());
         when(mockRequestHandler.sendDataToDocumentRenderService(any(String.class), any(RenderDocumentRequest.class))).thenThrow(IOException.class);
+        when(mockEnvironmentReader.getMandatoryString(any(String.class))).thenReturn(BUCKET_LOCATION);
 
         ResponseObject response = documentGeneratorService.generate(setValidRequest(), REQUEST_ID);
 
@@ -181,13 +187,14 @@ public class DocumentGeneratorServiceTest {
     private DocumentInfoResponse setSuccessfulDocumentInfo() {
 
         DocumentInfoResponse documentInfoResponse = new DocumentInfoResponse();
-        documentInfoResponse.setPath(LOCATION);
+        documentInfoResponse.setPath(PATH);
         documentInfoResponse.setTemplateName("templateName");
         documentInfoResponse.setData("data");
         documentInfoResponse.setAssetId("assetId");
         documentInfoResponse.setDescription(DESCRIPTION);
         documentInfoResponse.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
         documentInfoResponse.setDescriptionValues(setDescriptionValue());
+        documentInfoResponse.setContentType("contentType");
 
         return documentInfoResponse;
     }

--- a/document-generator-interfaces/src/main/java/uk/gov/companieshouse/document/generator/interfaces/model/DocumentInfoResponse.java
+++ b/document-generator-interfaces/src/main/java/uk/gov/companieshouse/document/generator/interfaces/model/DocumentInfoResponse.java
@@ -43,7 +43,7 @@ public class DocumentInfoResponse {
         return path;
     }
 
-    public void setPath(String location) {
+    public void setPath(String path) {
         this.path = path;
     }
 


### PR DESCRIPTION
A new method called BuildLocation which takes in a string called Path, using a StringBuilder it will construct the location that the document will be stored. 

Additional changes

- Added a similar method in the Junit to construct the Location with a StringBuilder for testing
- Updated the setting of the URL  string in renderSubmittedDocumentData to construct with a StringBuilder.
- Added private static variables.
- Corrected SetPath in DocumentInfoResponse 