### PR TITLE
Document Generator Small full balance sheet Period IXBRL model Mapper

### DIFF
--- a/document-generator-accounts/pom.xml
+++ b/document-generator-accounts/pom.xml
@@ -26,7 +26,7 @@
 
         <!--Dependencies-->
         <spring-boot-start-web.version>2.0.4.RELEASE</spring-boot-start-web.version>
-        <api-sdk-java.version>3.6.0-rc1</api-sdk-java.version>
+        <api-sdk-java.version>3.8.0-rc1</api-sdk-java.version>
         <environment-reader-library.version>1.2.0-rc1</environment-reader-library.version>
         <structured-logging.version>1.3.0-rc1</structured-logging.version>
 

--- a/document-generator-accounts/pom.xml
+++ b/document-generator-accounts/pom.xml
@@ -26,13 +26,15 @@
 
         <!--Dependencies-->
         <spring-boot-start-web.version>2.0.4.RELEASE</spring-boot-start-web.version>
-        <api-sdk-java.version>3.0.0-rc1</api-sdk-java.version>
+        <api-sdk-java.version>3.6.0-rc1</api-sdk-java.version>
         <environment-reader-library.version>1.2.0-rc1</environment-reader-library.version>
         <structured-logging.version>1.3.0-rc1</structured-logging.version>
 
         <!-- JUnit Testing -->
         <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>2.18.0</mockito-junit-jupiter.version>
+
+        <company-accounts-library.version>1.0.0-rc2</company-accounts-library.version>
     </properties>
 
     <dependencies>
@@ -75,6 +77,11 @@
             <version>${mockito-junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>company-accounts-library</artifactId>
+            <version>${company-accounts-library.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -98,6 +105,10 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapper.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapper.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mappers;
+
+import org.mapstruct.DecoratedWith;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.period.Period;
+
+@Mapper
+@DecoratedWith(ApiToPeriodMapperDecorator.class)
+public interface ApiToPeriodMapper {
+
+    ApiToPeriodMapper INSTANCE = Mappers.getMapper(ApiToPeriodMapper.class);
+
+    @Mappings({
+            @Mapping(source = "accounts.nextAccounts.periodStartOn", target = "currentPeriodStartOn"),
+            @Mapping(source = "accounts.nextAccounts.periodEndOn", target = "currentPeriodEndsOn"),
+            @Mapping(source = "accounts.lastAccounts.periodStartOn", target = "previousPeriodStartOn"),
+            @Mapping(source = "accounts.lastAccounts.periodEndOn", target = "previousPeriodEndsOn"),
+    })
+    Period apiToPeriod(CompanyProfileApi companyProfile);
+}
+

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperDecorator.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperDecorator.java
@@ -27,12 +27,22 @@ public abstract class ApiToPeriodMapperDecorator implements ApiToPeriodMapper {
 
         boolean isSameYear = isSameYearFiler(companyProfile);
 
+        setCurrentPeriod(period, companyProfile, isSameYear);
+        setPreviousPeriod(period, companyProfile, isSameYear);
+
+        return period;
+    }
+
+    private void setCurrentPeriod(Period period, CompanyProfileApi companyProfile, boolean isSameYear) {
+
         NextAccountsApi nextAccounts = companyProfile.getAccounts().getNextAccounts();
         period.setCurrentPeriodStartOnFormatted(convertToDisplayDate(nextAccounts.getPeriodStartOn()));
         period.setCurrentPeriodEndOnFormatted(convertToDisplayDate(nextAccounts.getPeriodEndOn()));
         period.setCurrentPeriodBSDate(convertDateToBSDate(nextAccounts.getPeriodStartOn(),
                 nextAccounts.getPeriodEndOn(), isSameYear));
+    }
 
+    private void setPreviousPeriod(Period period, CompanyProfileApi companyProfile, boolean isSameYear) {
 
         if (isMultipleYearFiler(companyProfile)) {
             LastAccountsApi lastAccounts = companyProfile.getAccounts().getLastAccounts();
@@ -41,8 +51,6 @@ public abstract class ApiToPeriodMapperDecorator implements ApiToPeriodMapper {
             period.setPreviousPeriodBSDate(convertDateToBSDate(lastAccounts.getPeriodStartOn(),
                     lastAccounts.getPeriodEndOn(), isSameYear));
         }
-
-        return period;
     }
 
     private boolean isMultipleYearFiler(CompanyProfileApi companyProfile) {

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperDecorator.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperDecorator.java
@@ -1,0 +1,69 @@
+package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mappers;
+
+import uk.gov.companieshouse.accountsdates.AccountsDatesHelper;
+import uk.gov.companieshouse.accountsdates.impl.AccountsDatesHelperImpl;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.api.model.company.account.LastAccountsApi;
+import uk.gov.companieshouse.api.model.company.account.NextAccountsApi;
+import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.period.Period;
+
+import java.time.LocalDate;
+
+
+public abstract class ApiToPeriodMapperDecorator implements ApiToPeriodMapper {
+
+    private final ApiToPeriodMapper apiToPeriodMapper;
+
+    private AccountsDatesHelper accountsDatesHelper = new AccountsDatesHelperImpl();
+
+    public ApiToPeriodMapperDecorator(ApiToPeriodMapper apiToPeriodMapper) {
+        this.apiToPeriodMapper = apiToPeriodMapper;
+    }
+
+    @Override
+    public Period apiToPeriod(CompanyProfileApi companyProfile) {
+
+        Period period = apiToPeriodMapper.apiToPeriod(companyProfile);
+
+        boolean isSameYear = isSameYearFiler(companyProfile);
+
+        NextAccountsApi nextAccounts = companyProfile.getAccounts().getNextAccounts();
+        period.setCurrentPeriodStartOnFormatted(convertToDisplayDate(nextAccounts.getPeriodStartOn()));
+        period.setCurrentPeriodEndOnFormatted(convertToDisplayDate(nextAccounts.getPeriodEndOn()));
+        period.setCurrentPeriodBSDate(convertDateToBSDate(nextAccounts.getPeriodStartOn(),
+                nextAccounts.getPeriodEndOn(), isSameYear));
+
+
+        if (isMultipleYearFiler(companyProfile)) {
+            LastAccountsApi lastAccounts = companyProfile.getAccounts().getLastAccounts();
+            period.setPreviousPeriodStartOnFormatted(convertToDisplayDate(lastAccounts.getPeriodStartOn()));
+            period.setPreviousPeriodEndOnFormatted(convertToDisplayDate(lastAccounts.getPeriodEndOn()));
+            period.setPreviousPeriodBSDate(convertDateToBSDate(lastAccounts.getPeriodStartOn(),
+                    lastAccounts.getPeriodEndOn(), isSameYear));
+        }
+
+        return period;
+    }
+
+    private boolean isMultipleYearFiler(CompanyProfileApi companyProfile) {
+        LastAccountsApi lastAccountsApi = companyProfile.getAccounts().getLastAccounts();
+        return lastAccountsApi != null && lastAccountsApi.getPeriodEndOn() != null;
+    }
+
+    private boolean isSameYearFiler(CompanyProfileApi companyProfile) {
+        if (isMultipleYearFiler(companyProfile)) {
+            LastAccountsApi lastAccountsApi = companyProfile.getAccounts().getLastAccounts();
+            NextAccountsApi nextAccountsApi = companyProfile.getAccounts().getNextAccounts();
+            return accountsDatesHelper.isSameYear(lastAccountsApi.getPeriodEndOn(), nextAccountsApi.getPeriodEndOn());
+        }
+        return false;
+    }
+
+    private String convertToDisplayDate(LocalDate date) {
+        return accountsDatesHelper.convertLocalDateToDisplayDate(date);
+    }
+
+    private String convertDateToBSDate(LocalDate dateStartOn, LocalDate dateEndOn, Boolean isSameYear) {
+        return accountsDatesHelper.generateBalanceSheetHeading(dateStartOn, dateEndOn, isSameYear);
+    }
+}

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.company.account.CompanyAccountApi;
 import uk.gov.companieshouse.api.model.company.account.LastAccountsApi;
@@ -20,9 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ApiToPeriodMapperTest {
-
-    @Autowired
-    private ApiToPeriodMapper apiToPeriodMapper;
 
     private static final String CURRENT_PERIOD_START_ON = "2018-01-01";
 
@@ -46,7 +42,7 @@ public class ApiToPeriodMapperTest {
 
     @Test
     @DisplayName("tests that the dates from Api are mapped to Period IXBRL model for multi year filings")
-    public void testApiMapsDatesToPeriodModelForMultiYearFiling() {
+    void testApiMapsDatesToPeriodModelForMultiYearFiling() {
 
         Period period = ApiToPeriodMapper.INSTANCE.apiToPeriod(setAccountsFilingDates(true));
 
@@ -65,7 +61,7 @@ public class ApiToPeriodMapperTest {
 
     @Test
     @DisplayName("tests that the dates from Api are mapped to Period IXBRL model for single year filings")
-    public void testApiMapsDatesToPeriodModelForSingleYearFiling() {
+    void testApiMapsDatesToPeriodModelForSingleYearFiling() {
 
         Period period = ApiToPeriodMapper.INSTANCE.apiToPeriod(setAccountsFilingDates(false));
 

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperTest.java
@@ -1,0 +1,106 @@
+package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mappers;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.api.model.company.account.CompanyAccountApi;
+import uk.gov.companieshouse.api.model.company.account.LastAccountsApi;
+import uk.gov.companieshouse.api.model.company.account.NextAccountsApi;
+import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.period.Period;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ApiToPeriodMapperTest {
+
+    @Autowired
+    private ApiToPeriodMapper apiToPeriodMapper;
+
+    private static final String CURRENT_PERIOD_START_ON = "2018-01-01";
+
+    private static final String CURRENT_PERIOD_END_ON = "2018-12-31";
+
+    private static final String PREVIOUS_PERIOD_START_ON = "2017-01-01";
+
+    private static final String PREVIOUS_PERIOD_END_ON = "2017-12-31";
+
+    private static final String CURRENT_PERIOD_START_ON_FORMATTED = "1 January 2018";
+
+    private static final String CURRENT_PERIOD_END_ON_FORMATTED = "31 December 2018";
+
+    private static final String PREVIOUS_PERIOD_START_ON_FORMATTED = "1 January 2017";
+
+    private static final String PREVIOUS_PERIOD_END_ON_FORMATTED = "31 December 2017";
+
+    private static final String CURRENT_PERIOD_BS_DATE = "2018";
+
+    private static final String PREVIOUS_PERIOD_BS_DATE = "2017";
+
+    @Test
+    @DisplayName("tests that the dates from Api are mapped to Period IXBRL model for multi year filings")
+    public void testApiMapsDatesToPeriodModelForMultiYearFiling() {
+
+        Period period = ApiToPeriodMapper.INSTANCE.apiToPeriod(setAccountsFilingDates(true));
+
+        assertNotNull(period);
+        assertEquals(CURRENT_PERIOD_START_ON, period.getCurrentPeriodStartOn());
+        assertEquals(CURRENT_PERIOD_END_ON, period.getCurrentPeriodEndsOn());
+        assertEquals(PREVIOUS_PERIOD_START_ON, period.getPreviousPeriodStartOn());
+        assertEquals(PREVIOUS_PERIOD_END_ON, period.getPreviousPeriodEndsOn());
+        assertEquals(CURRENT_PERIOD_START_ON_FORMATTED, period.getCurrentPeriodStartOnFormatted());
+        assertEquals(CURRENT_PERIOD_END_ON_FORMATTED, period.getCurrentPeriodEndOnFormatted());
+        assertEquals(PREVIOUS_PERIOD_START_ON_FORMATTED, period.getPreviousPeriodStartOnFormatted());
+        assertEquals(PREVIOUS_PERIOD_END_ON_FORMATTED, period.getPreviousPeriodEndOnFormatted());
+        assertEquals(CURRENT_PERIOD_BS_DATE, period.getCurrentPeriodBSDate());
+        assertEquals(PREVIOUS_PERIOD_BS_DATE, period.getPreviousPeriodBSDate());
+    }
+
+    @Test
+    @DisplayName("tests that the dates from Api are mapped to Period IXBRL model for single year filings")
+    public void testApiMapsDatesToPeriodModelForSingleYearFiling() {
+
+        Period period = ApiToPeriodMapper.INSTANCE.apiToPeriod(setAccountsFilingDates(false));
+
+        assertNotNull(period);
+        assertEquals(CURRENT_PERIOD_START_ON, period.getCurrentPeriodStartOn());
+        assertEquals(CURRENT_PERIOD_END_ON, period.getCurrentPeriodEndsOn());
+        assertEquals(null, period.getPreviousPeriodStartOn());
+        assertEquals(null, period.getPreviousPeriodEndsOn());
+        assertEquals(CURRENT_PERIOD_START_ON_FORMATTED, period.getCurrentPeriodStartOnFormatted());
+        assertEquals(CURRENT_PERIOD_END_ON_FORMATTED, period.getCurrentPeriodEndOnFormatted());
+        assertEquals(null, period.getPreviousPeriodStartOnFormatted());
+        assertEquals(null, period.getPreviousPeriodEndOnFormatted());
+        assertEquals(CURRENT_PERIOD_BS_DATE, period.getCurrentPeriodBSDate());
+        assertEquals(null, period.getPreviousPeriodBSDate());
+    }
+
+    private CompanyProfileApi setAccountsFilingDates(boolean multiYearFiling) {
+
+        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
+        CompanyAccountApi companyAccountsApi = new CompanyAccountApi();
+        LastAccountsApi lastAccountsApi = new LastAccountsApi();
+        NextAccountsApi nextAccountsApi = new NextAccountsApi();
+
+        if (multiYearFiling == true) {
+            lastAccountsApi.setPeriodEndOn(LocalDate.of(2017,12,31));
+            lastAccountsApi.setPeriodStartOn(LocalDate.of(2017, 01, 01));
+        }
+
+        nextAccountsApi.setPeriodEndOn(LocalDate.of(2018,12,31));
+        nextAccountsApi.setPeriodStartOn(LocalDate.of(2018,01,01));
+
+        companyAccountsApi.setLastAccounts(lastAccountsApi);
+        companyAccountsApi.setNextAccounts(nextAccountsApi);
+        companyProfileApi.setAccounts(companyAccountsApi);
+
+        return companyProfileApi;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <jdk.version>1.8</jdk.version>
 
         <!-- Maven and Surefire plugins -->
-        <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
         <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
         <junit-platform-surefire-provider.version>1.2.0</junit-platform-surefire-provider.version>
@@ -46,6 +46,8 @@
         <!--  JaCoCo -->
         <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
 
+        <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
+
     </properties>
 
     <dependencies>
@@ -58,6 +60,11 @@
             <groupId>org.sonarsource.scanner.maven</groupId>
             <artifactId>sonar-maven-plugin</artifactId>
             <version>${sonar-maven-plugin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${org.mapstruct.version}</version>
         </dependency>
     </dependencies>
 
@@ -141,6 +148,13 @@
                                 <meminitial>128m</meminitial>
                                 <encoding>${project.build.sourceEncoding}</encoding>
                                 <maxmem>512m</maxmem>
+                                <annotationProcessorPaths>
+                                    <path>
+                                        <groupId>org.mapstruct</groupId>
+                                        <artifactId>mapstruct-processor</artifactId>
+                                        <version>${org.mapstruct.version}</version>
+                                    </path>
+                                </annotationProcessorPaths>
                             </configuration>
                         </plugin>
                         <plugin>


### PR DESCRIPTION
Using MapStruct created an ApiToPeriod mapper to map the api data for period to the IXBRL model for small full

- Updated SDK version
- Added depedancy for company-accounts-library to enable the use of the datesHelper
- Updated the maven compiler version
- Added the mapStruct dependancy
- Created ApiToPeriodMapper interface with the @Mapping details
- Created ApiToPeriodMapperDecorator and added the @DecoratedWith annotation to ApiToWebMapper

The decorator is to enable custom mapping outside of the mapStruct as we need to format some of the dates held in the Period model using the DatesHelper from company-accounts-library

- Created Junit tests to test mapper.

Resolves SFA 646 & 857