### PR TITLE
Document Generator map api to ixbrl company model

### DIFF
--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCompanyMapper.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCompanyMapper.java
@@ -1,0 +1,21 @@
+package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.company.Company;
+
+@Mapper
+public interface ApiToCompanyMapper {
+
+    ApiToCompanyMapper INSTANCE = Mappers.getMapper(ApiToCompanyMapper.class);
+
+    @Mappings({
+            @Mapping(source = "companyProfile.companyNumber", target = "companyNumber"),
+            @Mapping(source = "companyProfile.companyName", target = "companyName"),
+            @Mapping(source = "companyProfile.jurisdiction", target = "jurisdiction")
+    })
+    Company apiToCompany(CompanyProfileApi companyProfile);
+}

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCompanyMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCompanyMapperTest.java
@@ -1,0 +1,39 @@
+package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mappers;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.company.Company;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ApiToCompanyMapperTest {
+
+    @Test
+    @DisplayName("tests company values map to company IXBRL model")
+    public void testApiToCompanyMaps() {
+
+        Company company = ApiToCompanyMapper.INSTANCE.apiToCompany(createCompanyProfile());
+
+        assertNotNull(company);
+        assertEquals("companyName", company.getCompanyName());
+        assertEquals("companyNumber", company.getCompanyNumber());
+        assertEquals("jurisdiction", company.getJurisdiction());
+    }
+
+    private CompanyProfileApi createCompanyProfile() {
+
+        CompanyProfileApi companyProfile = new CompanyProfileApi();
+        companyProfile.setCompanyName("companyName");
+        companyProfile.setCompanyNumber("companyNumber");
+        companyProfile.setJurisdiction("jurisdiction");
+
+        return companyProfile;
+    }
+}

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCompanyMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCompanyMapperTest.java
@@ -15,24 +15,30 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ApiToCompanyMapperTest {
 
+    private static final String JURISDICTION = "jurisdiction";
+
+    private static final String COMPANY_NAME = "companyName";
+
+    private static final String COMPANY_NUMBER = "companyNumber";
+
     @Test
     @DisplayName("tests company values map to company IXBRL model")
-    public void testApiToCompanyMaps() {
+    void testApiToCompanyMaps() {
 
-        Company company = ApiToCompanyMapper.INSTANCE.apiToCompany(createCompanyProfile());
+        Company company = ApiToCompanyMapper.INSTANCE.apiToCompany(setCompanyProfile());
 
         assertNotNull(company);
-        assertEquals("companyName", company.getCompanyName());
-        assertEquals("companyNumber", company.getCompanyNumber());
-        assertEquals("jurisdiction", company.getJurisdiction());
+        assertEquals(COMPANY_NAME, company.getCompanyName());
+        assertEquals(COMPANY_NUMBER, company.getCompanyNumber());
+        assertEquals(JURISDICTION, company.getJurisdiction());
     }
 
-    private CompanyProfileApi createCompanyProfile() {
+    private CompanyProfileApi setCompanyProfile() {
 
         CompanyProfileApi companyProfile = new CompanyProfileApi();
-        companyProfile.setCompanyName("companyName");
-        companyProfile.setCompanyNumber("companyNumber");
-        companyProfile.setJurisdiction("jurisdiction");
+        companyProfile.setCompanyName(COMPANY_NAME);
+        companyProfile.setCompanyNumber(COMPANY_NUMBER);
+        companyProfile.setJurisdiction(JURISDICTION);
 
         return companyProfile;
     }


### PR DESCRIPTION
Created ApiToCompany mapper to map company name, number and jurisdiction to the company ixbrl model.

- Create ApiToCompanyMapper
- Added Junit tests to test new mapper 

Resolves SFA 646 and 857