### PR TITLE
Document Generator balance sheet mapper correction

### DIFF
--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapper.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapper.java
@@ -15,7 +15,6 @@ public interface SmallFullIXBRLMapper {
     SmallFullIXBRLMapper INSTANCE = Mappers.getMapper(SmallFullIXBRLMapper.class);
 
     @Mappings({
-            @Mapping(source = "smallFullApiData.approval.date", target = "approvalDate"),
             @Mapping(source = "smallFullApiData.approval.name", target = "approvalName")
     })
     SmallFullAccountIxbrl mapSmallFullIXBRLModel(SmallFullApiData smallFullApiData);

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
@@ -1,14 +1,20 @@
 package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mappers;
 
+import uk.gov.companieshouse.accountsdates.AccountsDatesHelper;
+import uk.gov.companieshouse.accountsdates.impl.AccountsDatesHelperImpl;
 import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriodApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.PreviousPeriodApi;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.SmallFullApiData;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.SmallFullAccountIxbrl;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.balancesheet.BalanceSheet;
 
-public class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMapper {
+import java.time.LocalDate;
+
+public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMapper {
 
     private final SmallFullIXBRLMapper smallFullIXBRLMapper;
+
+    private AccountsDatesHelper accountsDatesHelper = new AccountsDatesHelperImpl();
 
     public SmallFullIXBRLMapperDecorator(SmallFullIXBRLMapper smallFullIXBRLMapper) {
         this.smallFullIXBRLMapper = smallFullIXBRLMapper;
@@ -21,6 +27,7 @@ public class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMapper {
         smallFullAccountIxbrl.setBalanceSheet(setBalanceSheet(smallFullApiData.getCurrentPeriod(), smallFullApiData.getPreviousPeriod()));
         smallFullAccountIxbrl.setCompany(ApiToCompanyMapper.INSTANCE.apiToCompany(smallFullApiData.getCompanyProfile()));
         smallFullAccountIxbrl.setPeriod(ApiToPeriodMapper.INSTANCE.apiToPeriod(smallFullApiData.getCompanyProfile()));
+        smallFullAccountIxbrl.setApprovalDate(convertToDisplayDate(smallFullApiData.getApproval().getDate()));
 
         return smallFullAccountIxbrl;
     }
@@ -36,5 +43,9 @@ public class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMapper {
         balanceSheet.setCapitalAndReserve(ApiToBalanceSheetMapper.INSTANCE.apiToCapitalAndReserve(currentPeriod, previousPeriod));
 
         return balanceSheet;
+    }
+
+    private String convertToDisplayDate(LocalDate date) {
+        return accountsDatesHelper.convertLocalDateToDisplayDate(date);
     }
 }

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperTest.java
@@ -311,7 +311,7 @@ public class SmallFullIXBRLMapperTest {
 
     private void assertApprovalsMapped(String approvalDate, String approvalName) {
 
-        assertEquals("2018-12-31", approvalDate);
+        assertEquals("31 December 2018", approvalDate);
         assertEquals(NAME, approvalName);
     }
 


### PR DESCRIPTION
Approval date was not formatted correctly.

- Moved mapping for approval date from interface @Mappings to decorator
- Added date formatter to convert approval date to correct format
- Formatted approval date with new formatter
- Corrected Decorator class to be abstract.
