### PR TITLE
Document Generator handle ApiErrorResponseException

### DIFF
--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
@@ -27,7 +27,10 @@ public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMap
         smallFullAccountIxbrl.setBalanceSheet(setBalanceSheet(smallFullApiData.getCurrentPeriod(), smallFullApiData.getPreviousPeriod()));
         smallFullAccountIxbrl.setCompany(ApiToCompanyMapper.INSTANCE.apiToCompany(smallFullApiData.getCompanyProfile()));
         smallFullAccountIxbrl.setPeriod(ApiToPeriodMapper.INSTANCE.apiToPeriod(smallFullApiData.getCompanyProfile()));
-        smallFullAccountIxbrl.setApprovalDate(convertToDisplayDate(smallFullApiData.getApproval().getDate()));
+
+        if (smallFullApiData.getApproval() != null & smallFullApiData.getApproval().getDate() != null) {
+            smallFullAccountIxbrl.setApprovalDate(convertToDisplayDate(smallFullApiData.getApproval().getDate()));
+        }
 
         return smallFullAccountIxbrl;
     }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
@@ -28,7 +28,7 @@ public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMap
         smallFullAccountIxbrl.setCompany(ApiToCompanyMapper.INSTANCE.apiToCompany(smallFullApiData.getCompanyProfile()));
         smallFullAccountIxbrl.setPeriod(ApiToPeriodMapper.INSTANCE.apiToPeriod(smallFullApiData.getCompanyProfile()));
 
-        if (smallFullApiData.getApproval() != null & smallFullApiData.getApproval().getDate() != null) {
+        if (smallFullApiData.getApproval() != null && smallFullApiData.getApproval().getDate() != null) {
             smallFullAccountIxbrl.setApprovalDate(convertToDisplayDate(smallFullApiData.getApproval().getDate()));
         }
 

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/impl/AccountsServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/impl/AccountsServiceImpl.java
@@ -75,7 +75,7 @@ public class AccountsServiceImpl implements AccountsService {
         try {
             LOG.infoContext(requestId, "Getting smallFull accounts data: " + resource, getDebugMap(resource));
             return accountsManager.getSmallFullAccounts(resource, transaction);
-        } catch (URIValidationException e) {
+        } catch (URIValidationException | ApiErrorResponseException e) {
             LOG.errorContext(requestId,"Failed to retrieve smallFull accounts data: ", e, getDebugMap(resource));
             throw new ServiceException(e.getMessage(), e.getCause());
         }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/impl/AccountsServiceImpl.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/service/impl/AccountsServiceImpl.java
@@ -75,7 +75,7 @@ public class AccountsServiceImpl implements AccountsService {
         try {
             LOG.infoContext(requestId, "Getting smallFull accounts data: " + resource, getDebugMap(resource));
             return accountsManager.getSmallFullAccounts(resource, transaction);
-        } catch (URIValidationException | ApiErrorResponseException e) {
+        } catch (URIValidationException e) {
             LOG.errorContext(requestId,"Failed to retrieve smallFull accounts data: ", e, getDebugMap(resource));
             throw new ServiceException(e.getMessage(), e.getCause());
         }


### PR DESCRIPTION
Updated the ApiErrorResponseException when calling the smallFull Api, as when a 404 is returned we should not be throwing an exception. All other ApiErrorResponseException will be dealt with as normal. 

Updated null checks for Approvals 