### PR TITLE
Update document generator api to remove use of resourceId

### DIFF
--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/controller/DocumentGeneratorController.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/controller/DocumentGeneratorController.java
@@ -48,7 +48,6 @@ public class DocumentGeneratorController {
         if (result.hasErrors()) {
             final Map<String, Object> debugMap = new HashMap<>();
             debugMap.put("resource_uri", documentRequest.getResourceUri());
-            debugMap.put("resource_id", documentRequest.getResourceId());
             LOG.debugRequest(request, "error in request body", debugMap);
             return new ResponseEntity<>(result.getAllErrors(), HttpStatus.BAD_REQUEST);
         }

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/document/description/RetrieveApiEnumerationDescription.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/document/description/RetrieveApiEnumerationDescription.java
@@ -12,7 +12,7 @@ public interface RetrieveApiEnumerationDescription {
      * @param identifier The identifier/key used to select the description
      * @param accountType The type of account
      * @param descriptionValues A map of the description values used to obtain the description
-     * @param requestParameters Map containing requestId, resourceId and resourceUri as a key/value pair
+     * @param requestParameters Map containing requestId and resourceUri as a key/value pair
      * @return String containing the description
      * @throws IOException
      */

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/document/render/RenderDocumentRequestHandler.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/document/render/RenderDocumentRequestHandler.java
@@ -14,7 +14,7 @@ public interface RenderDocumentRequestHandler {
      *
      * @param url a string formatted url
      * @param request the RenderDocumentRequest
-     * @param requestParameters Map containing requestId, resourceId and resourceUri as a key/value pair
+     * @param requestParameters Map containing requestId and resourceUri as a key/value pair
      * @return RenderDocumentResponse
      * @throws IOException
      */

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/models/DocumentRequest.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/models/DocumentRequest.java
@@ -14,6 +14,7 @@ public class DocumentRequest {
     /**
      * resource id will be removed
      */
+    @Deprecated
     @JsonProperty("resource_id")
     private String resourceId;
 

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/models/DocumentRequest.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/models/DocumentRequest.java
@@ -14,7 +14,6 @@ public class DocumentRequest {
     /**
      * resource id will be removed
      */
-    @Deprecated
     @JsonProperty("resource_id")
     private String resourceId;
 

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/models/DocumentRequest.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/models/DocumentRequest.java
@@ -11,7 +11,10 @@ public class DocumentRequest {
     @JsonProperty("resource_uri")
     private String resourceUri;
 
-    @NotNull
+    /**
+     * resource id will be removed
+     */
+    @Deprecated
     @JsonProperty("resource_id")
     private String resourceId;
 

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/DocumentTypeService.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/DocumentTypeService.java
@@ -10,7 +10,7 @@ public interface DocumentTypeService {
     /**
      * get Document type from the resource uri
      *
-     * @param requestParameters Map containing requestId, resourceId and resourceUri as a key/value pair
+     * @param requestParameters Map containing requestId and resourceUri as a key/value pair
      * @return DocumentType type of document requested
      * @throws ServiceException
      */

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
@@ -63,8 +63,6 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
 
     private static final String RESOURCE_URI = "resource_uri";
 
-    private static final String RESOURCE_ID = "resource_id";
-
     private static final String REQUEST_ID = "request_id";
 
     @Autowired
@@ -91,7 +89,6 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
 
         Map<String, String> requestParameters = new HashMap<>();
         requestParameters.put(RESOURCE_URI, documentRequest.getResourceUri());
-        requestParameters.put(RESOURCE_ID, documentRequest.getResourceId());
         requestParameters.put(REQUEST_ID, requestId);
 
         createAndLogInfoMessage("Generation of document for resource: "
@@ -170,7 +167,7 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
      *
      * @param documentRequest object that contains the request details from the Api call
      * @param documentInfoResponse object that contain the Response from documentInfoService
-     * @param requestParameters Map containing requestId, resourceId and resourceUri as a key/value pair
+     * @param requestParameters Map containing requestId and resourceUri as a key/value pair
      * @return A populated RenderDocumentResponse model or Null
      * @throws IOException
      */
@@ -201,7 +198,7 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
      * @param mimeType The content type of the document, also the document type if no document type set
      * @param documentType The document type
      * @param requestData The object containing the populated request data for the render service
-     * @param requestParameters Map containing requestId, resourceId and resourceUri as a key/value pair
+     * @param requestParameters Map containing requestId and resourceUri as a key/value pair
      * @throws IOException
      */
     private void setContentAndDocumentType(String mimeType, String documentType, RenderDocumentRequest requestData,
@@ -239,7 +236,7 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
      *
      * @param renderResponse object that contains the RenderDocumentResponse details
      * @param documentInfoResponse object that contains the Response from documentInfoService
-     * @param requestParameters Map containing requestId, resourceId and resourceUri as a key/value pair
+     * @param requestParameters Map containing requestId and resourceUri as a key/value pair
      * @return a Document Response
      * @return
      */
@@ -267,7 +264,7 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
      * Get the document description from an api enumeration file
      *
      * @param documentInfoResponse object that contains the Response from documentInfoService
-     * @param requestParameters Map containing requestId, resourceId and resourceUri as a key/value pair
+     * @param requestParameters Map containing requestId and resourceUri as a key/value pair
      * @return String containing the description
      */
     private String getDescription(DocumentInfoResponse documentInfoResponse, Map<String, String> requestParameters) {
@@ -291,7 +288,7 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
      *
      * @param message The message to be logged
      * @param <T> generic exception parameter to be stored in message
-     * @param requestParameters Map containing requestId, resourceId and resourceUri as a key/value pair
+     * @param requestParameters Map containing requestId and resourceUri as a key/value pair
      */
     private <T extends Exception> void createAndLogErrorMessage(String message, T exception,
                                                                 Map<String, String> requestParameters) {
@@ -315,7 +312,7 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
      * Create and log Info Message
      *
      * @param message message to be logged
-     * @param requestParameters Map containing requestId, resourceId and resourceUri as a key/value pair
+     * @param requestParameters Map containing requestId and resourceUri as a key/value pair
      */
     private void createAndLogInfoMessage(String message, Map<String, String> requestParameters) {
         LOG.infoContext(requestParameters.get(REQUEST_ID), message, setDebugMap(requestParameters));
@@ -325,7 +322,6 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
 
         Map <String, Object> debugMap = new HashMap <>();
         debugMap.put(RESOURCE_URI, requestParameters.get(RESOURCE_URI));
-        debugMap.put(RESOURCE_ID, requestParameters.get(RESOURCE_ID));
 
         return debugMap;
     }

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentTypeServiceImpl.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentTypeServiceImpl.java
@@ -20,8 +20,6 @@ public class DocumentTypeServiceImpl implements DocumentTypeService {
 
     private static final String RESOURCE_URI = "resource_uri";
 
-    private static final String RESOURCE_ID = "resource_id";
-
     private static final String REQUEST_ID = "request_id";
 
     /**
@@ -42,7 +40,6 @@ public class DocumentTypeServiceImpl implements DocumentTypeService {
 
         Map<String, Object> debugMap = new HashMap<>();
         debugMap.put(RESOURCE_URI, requestParameters.get(RESOURCE_URI));
-        debugMap.put(RESOURCE_ID, requestParameters.get(RESOURCE_ID));
 
         return  debugMap;
     }


### PR DESCRIPTION
Update to document generator api to remove use of resourceId and change to use solely resourceUri

Updated document-generator-api to deprecated resourceId in the DocumentRequest model
Removed all use of resourceId from document-generator-api