### PR TITLE
Document-Generator jackson null serialisation

### DIFF
--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/AbridgedAccountsDataHandler.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/AbridgedAccountsDataHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.document.generator.accounts.handler.accounts;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.json.JSONObject;
@@ -169,6 +170,7 @@ public class AbridgedAccountsDataHandler {
     private String writeAccountsValues(AbridgedAccountsApiData abridgedAccountsApiData) throws IOException {
 
         ObjectMapper mapper = new ObjectMapper();
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         String accountsJSON = mapper.writeValueAsString(abridgedAccountsApiData);
         JsonNode accounts = mapper.readTree(accountsJSON);
 


### PR DESCRIPTION
When serialising the Json from the abridgedAccountsApiData model, nested nulls were being creating and causing an issue with the IXBRL template. 

- added mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL) to set the serialisation rule for nulls on the mapper level. 

This rectifies the issue, without having to add the null checks to the IXBRL,

Resolves SFA - SFA-1004