### PR TITLE
Updating Doc. Generator to return private or public location 

### DIFF
--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/models/DocumentRequest.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/models/DocumentRequest.java
@@ -25,6 +25,9 @@ public class DocumentRequest {
     @JsonProperty("document_type")
     private String documentType;
 
+    @JsonProperty("is_public_location_required")
+    private boolean isPublicLocationRequired;
+
     public String getResourceUri() {
         return resourceUri;
     }
@@ -55,6 +58,14 @@ public class DocumentRequest {
 
     public void setDocumentType(String documentType) {
         this.documentType = documentType;
+    }
+
+    public boolean isPublicLocationRequired() {
+        return isPublicLocationRequired;
+    }
+
+    public void setPublicLocationRequired(boolean publicLocationRequired) {
+        isPublicLocationRequired = publicLocationRequired;
     }
 
     @Override

--- a/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentGeneratorServiceTest.java
+++ b/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentGeneratorServiceTest.java
@@ -188,6 +188,7 @@ public class DocumentGeneratorServiceTest {
         request.setResourceUri("/transactions/091174-913515-326060/accounts/xU-6Vebn7F8AgLwa2QHBUL2yRpk=");
         request.setMimeType("text/html");
         request.setDocumentType("documentType");
+        request.setPublicLocationRequired(true);
 
         return request;
     }

--- a/document-generator-api/swagger-2.0/models/document-generator.json
+++ b/document-generator-api/swagger-2.0/models/document-generator.json
@@ -23,6 +23,10 @@
         "document_type": {
           "type": "string",
           "description": "indicates the document or report type to be generated from the resource data. Currently not implemented"
+        },
+        "is_public_location_required": {
+          "type": "boolean",
+          "description": "indicates that a public location is needed when informing where the document has been stored"
         }
 
       }
@@ -72,7 +76,7 @@
       "properties": {
         "location": {
           "type": "string",
-          "description": "location that the document has been stored"
+          "description": "location where the document has been stored, which can be private (default) or public. To request a public location, the is_public_location_required flag needs to be passed as true"
         }
       }
     }


### PR DESCRIPTION
Changes made to the Doc. Generator to return either public or private ixbrl location.

The Doc. Generator will return a private location by default. If a public location is required; it needs to be specified in the request by setting _is_public_location_required_ to true.

- Changes in the model to add a new flag that will control if a public location needs to be returned for the ixbrl.

- Changes in the DocumentGeneratorServiceImpl to get the correct context path to retrieve private or public location; this decision will be based on the new flag being set to true

Resolves: 
SFA-1018