### PR TITLE
Add environment variable check on document genenerator startup

### DIFF
--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/DocumentGeneratorApplication.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/DocumentGeneratorApplication.java
@@ -76,7 +76,7 @@ public class DocumentGeneratorApplication implements WebMvcConfigurer {
                 String paramValue = reader.getMandatoryString(param);
                 LOGGER.info("Environment variable " + param + " has value " + paramValue);
                 } catch (EnvironmentVariableException e) {
-                LOGGER.error("Environment variable " + param + " is not set");
+                LOGGER.error("Environment variable " + param + " is not set", e);
                 environmentParamMissing.set(true);
             }
         });

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/DocumentGeneratorApplication.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/DocumentGeneratorApplication.java
@@ -6,20 +6,42 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import uk.gov.companieshouse.document.generator.api.interceptor.LoggingInterceptor;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.environment.exception.EnvironmentVariableException;
+import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @SpringBootApplication
 public class DocumentGeneratorApplication implements WebMvcConfigurer {
 
     public static final String APPLICATION_NAME_SPACE = "document-generator-api";
 
+    public static final String DOCUMENT_RENDER_SERVICE_HOST_ENV_VAR = "DOCUMENT_RENDER_SERVICE_HOST";
+
+    public static final String DOCUMENT_BUCKET_NAME_ENV_VAR = "DOCUMENT_BUCKET_NAME";
+
+    private static final String CHS_API_KEY = "CHS_API_KEY";
+
+    private static final String API_URL = "API_URL";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
 
     @Autowired
     private LoggingInterceptor loggingInterceptor;
 
+    private static EnvironmentReader reader;
+
     public static void main(String[] args) {
+
+        reader = new EnvironmentReaderImpl();
+
+        checkEnvironmentParams();
+
         Integer port = Integer.getInteger("server.port");
 
         if (port == null) {
@@ -28,6 +50,41 @@ public class DocumentGeneratorApplication implements WebMvcConfigurer {
         }
 
         SpringApplication.run(DocumentGeneratorApplication.class, args);
+    }
+
+    /**
+     * Check all expected Environment variables are set
+     */
+    public static void checkEnvironmentParams() {
+
+        List<String> environmentParams = new ArrayList<>();
+
+        environmentParams.add(DOCUMENT_RENDER_SERVICE_HOST_ENV_VAR);
+        environmentParams.add(DOCUMENT_BUCKET_NAME_ENV_VAR);
+        environmentParams.add(CHS_API_KEY);
+        environmentParams.add(API_URL);
+        checkParams(environmentParams);
+    }
+
+    private static void checkParams(List<String> environmentParams) {
+
+        AtomicBoolean environmentParamMissing = new AtomicBoolean(false);
+
+        environmentParams.stream().forEach(param -> {
+
+            try {
+                String paramValue = reader.getMandatoryString(param);
+                LOGGER.info("Environment variable " + param + " has value " + paramValue);
+                } catch (EnvironmentVariableException e) {
+                LOGGER.error("Environment variable " + param + " is not set");
+                environmentParamMissing.set(true);
+            }
+        });
+
+        if (environmentParamMissing.get() == true) {
+            throw new RuntimeException("There are environment variables that " +
+                "are not set, see logs for details - application will exit");
+        }
     }
 
     @Override

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
@@ -1,14 +1,10 @@
 package uk.gov.companieshouse.document.generator.api.service.impl;
 
-import static uk.gov.companieshouse.document.generator.api.DocumentGeneratorApplication.APPLICATION_NAME_SPACE;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.http.HttpStatus;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.document.generator.api.DocumentGeneratorApplication;
 import uk.gov.companieshouse.document.generator.api.document.DocumentType;
 import uk.gov.companieshouse.document.generator.api.document.description.RetrieveApiEnumerationDescription;
 import uk.gov.companieshouse.document.generator.api.document.render.RenderDocumentRequestHandler;
@@ -31,6 +27,12 @@ import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static uk.gov.companieshouse.document.generator.api.DocumentGeneratorApplication.APPLICATION_NAME_SPACE;
+
 @Service
 public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
 
@@ -43,10 +45,6 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
     private DocumentInfoServiceFactory documentInfoServiceFactory;
 
     private RetrieveApiEnumerationDescription retrieveApiEnumerationDescription;
-
-    private static final String DOCUMENT_RENDER_SERVICE_HOST_ENV_VAR = "DOCUMENT_RENDER_SERVICE_HOST";
-
-    private static final String DOCUMENT_BUCKET_NAME_ENV_VAR = "DOCUMENT_BUCKET_NAME";
 
     private static final String S3 = "s3://";
 
@@ -177,7 +175,7 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
                                                                Map<String, String> requestParameters)
             throws IOException, RenderServiceException {
 
-        String host = environmentReader.getMandatoryString(DOCUMENT_RENDER_SERVICE_HOST_ENV_VAR);
+        String host = environmentReader.getMandatoryString(DocumentGeneratorApplication.DOCUMENT_RENDER_SERVICE_HOST_ENV_VAR);
         String url = host + getContextPath(documentRequest.isPublicLocationRequired());
 
         RenderDocumentRequest requestData = new RenderDocumentRequest();
@@ -243,7 +241,7 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
      */
     private String buildLocation(String path) {
 
-        String bucketName = environmentReader.getMandatoryString(DOCUMENT_BUCKET_NAME_ENV_VAR);
+        String bucketName = environmentReader.getMandatoryString(DocumentGeneratorApplication.DOCUMENT_BUCKET_NAME_ENV_VAR);
 
         return new StringBuilder(S3).append(bucketName).append(path).toString();
     }


### PR DESCRIPTION
Added a check on document generator start up to see if the environment variables are present. If they are not, highlight which are missing and throw RunTimeException. 

Resolves SFA-715