### PR TITLE
Move description formatting out of document-generator

### DIFF
--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/CompanyAccountsDataHandler.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/CompanyAccountsDataHandler.java
@@ -3,8 +3,6 @@ package uk.gov.companieshouse.document.generator.accounts.handler.accounts;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.accountsdates.AccountsDatesHelper;
-import uk.gov.companieshouse.accountsdates.impl.AccountsDatesHelperImpl;
 import uk.gov.companieshouse.api.model.accounts.CompanyAccounts;
 import uk.gov.companieshouse.document.generator.accounts.AccountType;
 import uk.gov.companieshouse.document.generator.accounts.data.accounts.CompanyAccountsDocumentDataManager;
@@ -14,14 +12,12 @@ import uk.gov.companieshouse.document.generator.accounts.exception.AccountsLinkN
 import uk.gov.companieshouse.document.generator.accounts.exception.ServiceException;
 import uk.gov.companieshouse.document.generator.accounts.mapping.PeriodAwareIxbrl;
 import uk.gov.companieshouse.document.generator.accounts.service.AccountsService;
-import uk.gov.companieshouse.document.generator.accounts.service.CompanyService;
 import uk.gov.companieshouse.document.generator.accounts.service.TransactionService;
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoResponse;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.io.IOException;
-import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,15 +32,10 @@ public class CompanyAccountsDataHandler {
     private AccountsService accountsService;
 
     @Autowired
-    private CompanyService companyService;
-
-    @Autowired
     private TransactionService transactionService;
 
     @Autowired
     private CompanyAccountsDocumentDataManager companyAccountsDocumentDataManager;
-
-    private AccountsDatesHelper accountsDatesHelper = new AccountsDatesHelperImpl();
 
     private static final String RESOURCE_URI = "resourceUri";
 
@@ -142,8 +133,7 @@ public class CompanyAccountsDataHandler {
         documentInfoResponse.setPath(createPathString(accountType));
 
         Map<String, String> descriptionValues = new HashMap<>();
-        descriptionValues.put("period_end_on", accountsDatesHelper
-                .convertLocalDateToDisplayDate(getCurrentPeriodEndOn(accountData)));
+        descriptionValues.put("period_end_on", getCurrentPeriodEndOn(accountData));
 
         documentInfoResponse.setDescriptionValues(descriptionValues);
         documentInfoResponse.setDescriptionIdentifier(accountType.getEnumerationKey());
@@ -161,11 +151,7 @@ public class CompanyAccountsDataHandler {
         return mapper.writeValueAsString(accountData);
     }
 
-    private <T extends PeriodAwareIxbrl> LocalDate getCurrentPeriodEndOn(T accountData) {
-        return formatDate(accountData.getPeriod().getCurrentPeriodEndsOn());
-    }
-
-    private LocalDate formatDate(String date) {
-        return accountsDatesHelper.convertStringToDate(date);
+    private <T extends PeriodAwareIxbrl> String getCurrentPeriodEndOn(T accountData) {
+        return accountData.getPeriod().getCurrentPeriodEndsOn();
     }
 }

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/CompanyAccountsDataHandler.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/handler/accounts/CompanyAccountsDataHandler.java
@@ -143,7 +143,7 @@ public class CompanyAccountsDataHandler {
 
         Map<String, String> descriptionValues = new HashMap<>();
         descriptionValues.put("period_end_on", accountsDatesHelper
-                .convertDateToString(getCurrentPeriodEndOn(accountData)));
+                .convertLocalDateToDisplayDate(getCurrentPeriodEndOn(accountData)));
 
         documentInfoResponse.setDescriptionValues(descriptionValues);
         documentInfoResponse.setDescriptionIdentifier(accountType.getEnumerationKey());

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/document/description/impl/RetrieveApiEnumerationDescriptionImpl.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/document/description/impl/RetrieveApiEnumerationDescriptionImpl.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.document.generator.api.document.description.impl;
 
-import org.apache.commons.lang.text.StrSubstitutor;
 import org.springframework.stereotype.Service;
 import org.yaml.snakeyaml.Yaml;
 import uk.gov.companieshouse.document.generator.api.document.description.RetrieveApiEnumerationDescription;
@@ -58,7 +57,7 @@ public class RetrieveApiEnumerationDescriptionImpl implements RetrieveApiEnumera
                     "descriptions for file name: " + descriptionsFile, e, setDebugMap(requestParameters));
         }
 
-        return populateParameters(description, parameters);
+        return description;
     }
 
     /**
@@ -84,18 +83,6 @@ public class RetrieveApiEnumerationDescriptionImpl implements RetrieveApiEnumera
                             setDebugMap(requestParameters));
                     return null;
                 });
-    }
-
-    /**
-     * Populate the parameters in the description
-     *
-     * @param description
-     * @param parameters
-     * @return description
-     */
-    private static String populateParameters(Object description, Map<String, String> parameters) {
-        StrSubstitutor sub = new StrSubstitutor(parameters, "{", "}");
-        return sub.replace(description);
     }
 
     private Map<String, Object> setDebugMap(Map<String, String> requestParameters) {

--- a/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/document/RetrieveApiEnumerationDescriptionTest.java
+++ b/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/document/RetrieveApiEnumerationDescriptionTest.java
@@ -22,7 +22,7 @@ public class RetrieveApiEnumerationDescriptionTest {
 
     private static final String DESCRIPTION_IDENTIFIERS_KEY_INVALID = "desc";
 
-    private static final String POPULATED_RESPONSE = "Abridged accounts made up to 01 October 2018";
+    private static final String POPULATED_RESPONSE = "Abridged accounts made up to {period_end_on}";
 
     private static final String EMPTY_RESPONSE = "";
 


### PR DESCRIPTION
Moves the description formatting out of the document-generator and into the filing generator (in accounts api).

Resolves:
SFA-870