### PR TITLE
Scope mappers to the request for thread safety

### DIFF
--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/accounts/AccountsManager.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/data/accounts/AccountsManager.java
@@ -52,6 +52,9 @@ public class AccountsManager {
     @Autowired
     private CompanyService companyService;
 
+    @Autowired
+    private SmallFullIXBRLMapper smallFullIXBRLMapper;
+
     private static final Logger LOG = LoggerFactory.getLogger(MODULE_NAME_SPACE);
 
     private static final String NOT_FOUND_API_DATA = "No data found in %s api for link: ";
@@ -219,7 +222,7 @@ public class AccountsManager {
         smallFullApiData.setCompanyProfile(companyService.getCompanyProfile(transaction.getCompanyNumber()));
 
 
-        return SmallFullIXBRLMapper.INSTANCE.mapSmallFullIXBRLModel(smallFullApiData);
+        return smallFullIXBRLMapper.mapSmallFullIXBRLModel(smallFullApiData);
     }
 
     private void handleException(ApiErrorResponseException e, String text, String link)

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToAccountingPoliciesMapper.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToAccountingPoliciesMapper.java
@@ -3,14 +3,13 @@ package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mapp
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
-import org.mapstruct.factory.Mappers;
+import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.companieshouse.api.model.accounts.smallfull.AccountingPoliciesApi;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.accountingpolicies.AccountingPolicies;
 
-@Mapper
+@RequestScope
+@Mapper(componentModel = "spring")
 public interface ApiToAccountingPoliciesMapper {
-
-    ApiToAccountingPoliciesMapper INSTANCE = Mappers.getMapper(ApiToAccountingPoliciesMapper.class);
 
     @Mappings({
             @Mapping(source = "accountingPolicies.basisOfMeasurementAndPreparation", target = "basisOfMeasurementAndPreparation"),

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToBalanceSheetMapper.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToBalanceSheetMapper.java
@@ -3,7 +3,7 @@ package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mapp
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
-import org.mapstruct.factory.Mappers;
+import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.companieshouse.api.model.accounts.smallfull.BalanceSheetStatementsApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriodApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.PreviousPeriodApi;
@@ -14,10 +14,9 @@ import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.balancesheet.fixedassets.FixedAssets;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.balancesheet.otherliabilitiesandassets.OtherLiabilitiesOrAssets;
 
-@Mapper
+@RequestScope
+@Mapper(componentModel = "spring")
 public interface ApiToBalanceSheetMapper {
-
-    ApiToBalanceSheetMapper INSTANCE = Mappers.getMapper(ApiToBalanceSheetMapper.class);
 
     @Mappings({
             @Mapping(source = "currentPeriod.balanceSheet.capitalAndReserves.calledUpShareCapital",

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCompanyMapper.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCompanyMapper.java
@@ -3,14 +3,13 @@ package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mapp
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
-import org.mapstruct.factory.Mappers;
+import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.company.Company;
 
-@Mapper
+@RequestScope
+@Mapper(componentModel = "spring")
 public interface ApiToCompanyMapper {
-
-    ApiToCompanyMapper INSTANCE = Mappers.getMapper(ApiToCompanyMapper.class);
 
     @Mappings({
             @Mapping(source = "companyProfile.companyNumber", target = "companyNumber"),

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCreditorsAfterOneYearMapper.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCreditorsAfterOneYearMapper.java
@@ -3,15 +3,14 @@ package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mapp
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
-import org.mapstruct.factory.Mappers;
+import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.companieshouse.api.model.accounts.smallfull.creditorsafteroneyear.CurrentPeriod;
 import uk.gov.companieshouse.api.model.accounts.smallfull.creditorsafteroneyear.PreviousPeriod;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.creditorsafteroneyear.CreditorsAfterOneYear;
 
-@Mapper
+@RequestScope
+@Mapper(componentModel = "spring")
 public interface ApiToCreditorsAfterOneYearMapper {
-
-    ApiToCreditorsAfterOneYearMapper INSTANCE = Mappers.getMapper(ApiToCreditorsAfterOneYearMapper.class);
 
     @Mappings({
 

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCreditorsWithinOneYearMapper.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCreditorsWithinOneYearMapper.java
@@ -3,15 +3,14 @@ package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mapp
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
-import org.mapstruct.factory.Mappers;
+import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.companieshouse.api.model.accounts.smallfull.creditorswithinoneyear.CurrentPeriod;
 import uk.gov.companieshouse.api.model.accounts.smallfull.creditorswithinoneyear.PreviousPeriod;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.creditorswithinoneyear.CreditorsWithinOneYear;
 
-@Mapper
+@RequestScope
+@Mapper(componentModel = "spring")
 public interface ApiToCreditorsWithinOneYearMapper {
-
-    ApiToCreditorsWithinOneYearMapper INSTANCE = Mappers.getMapper(ApiToCreditorsWithinOneYearMapper.class);
 
     @Mappings({
             @Mapping(source = "creditorsWithinOneYearCurrentPeriod.accrualsAndDeferredIncome",

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToDebtorsMapper.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToDebtorsMapper.java
@@ -3,15 +3,14 @@ package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mapp
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
-import org.mapstruct.factory.Mappers;
+import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.companieshouse.api.model.accounts.smallfull.Debtors.CurrentPeriod;
 import uk.gov.companieshouse.api.model.accounts.smallfull.Debtors.PreviousPeriod;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.debtors.Debtors;
 
-@Mapper
+@RequestScope
+@Mapper(componentModel = "spring")
 public interface ApiToDebtorsMapper {
-
-    ApiToDebtorsMapper INSTANCE = Mappers.getMapper(ApiToDebtorsMapper.class);
 
     @Mappings({
             @Mapping(source = "debtorsCurrentPeriod.greaterThanOneYear",

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapper.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapper.java
@@ -4,15 +4,14 @@ import org.mapstruct.DecoratedWith;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
-import org.mapstruct.factory.Mappers;
+import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.period.Period;
 
-@Mapper
+@RequestScope
+@Mapper(componentModel = "spring")
 @DecoratedWith(ApiToPeriodMapperDecorator.class)
 public interface ApiToPeriodMapper {
-
-    ApiToPeriodMapper INSTANCE = Mappers.getMapper(ApiToPeriodMapper.class);
 
     @Mappings({
             @Mapping(source = "accounts.nextAccounts.periodStartOn", target = "currentPeriodStartOn"),

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperDecorator.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperDecorator.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mappers;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import uk.gov.companieshouse.accountsdates.AccountsDatesHelper;
 import uk.gov.companieshouse.accountsdates.impl.AccountsDatesHelperImpl;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
@@ -12,13 +14,11 @@ import java.time.LocalDate;
 
 public abstract class ApiToPeriodMapperDecorator implements ApiToPeriodMapper {
 
-    private final ApiToPeriodMapper apiToPeriodMapper;
+    @Autowired
+    @Qualifier("delegate")
+    private ApiToPeriodMapper apiToPeriodMapper;
 
     private AccountsDatesHelper accountsDatesHelper = new AccountsDatesHelperImpl();
-
-    public ApiToPeriodMapperDecorator(ApiToPeriodMapper apiToPeriodMapper) {
-        this.apiToPeriodMapper = apiToPeriodMapper;
-    }
 
     @Override
     public Period apiToPeriod(CompanyProfileApi companyProfile) {

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperDecorator.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperDecorator.java
@@ -11,11 +11,10 @@ import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model
 
 import java.time.LocalDate;
 
-
 public abstract class ApiToPeriodMapperDecorator implements ApiToPeriodMapper {
 
     @Autowired
-    @Qualifier("delegate")
+    @Qualifier("apiToPeriodMapper")
     private ApiToPeriodMapper apiToPeriodMapper;
 
     private AccountsDatesHelper accountsDatesHelper = new AccountsDatesHelperImpl();

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperDecorator.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperDecorator.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 public abstract class ApiToPeriodMapperDecorator implements ApiToPeriodMapper {
 
     @Autowired
-    @Qualifier("apiToPeriodMapper")
+    @Qualifier("delegate")
     private ApiToPeriodMapper apiToPeriodMapper;
 
     private AccountsDatesHelper accountsDatesHelper = new AccountsDatesHelperImpl();

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToStocksMapper.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToStocksMapper.java
@@ -3,15 +3,14 @@ package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mapp
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
-import org.mapstruct.factory.Mappers;
+import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.companieshouse.api.model.accounts.smallfull.stocks.CurrentPeriod;
 import uk.gov.companieshouse.api.model.accounts.smallfull.stocks.PreviousPeriod;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.stocks.StocksNote;
 
-@Mapper
+@RequestScope
+@Mapper(componentModel = "spring")
 public interface ApiToStocksMapper {
-
-    ApiToStocksMapper INSTANCE = Mappers.getMapper(ApiToStocksMapper.class);
 
     @Mappings({
             @Mapping(source = "stocksCurrentPeriod.stocks",

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToTangibleAssetsNoteMapper.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToTangibleAssetsNoteMapper.java
@@ -3,15 +3,14 @@ package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mapp
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
-import org.mapstruct.factory.Mappers;
+import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.companieshouse.api.model.accounts.smallfull.tangible.TangibleApi;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.notes.tangible.TangibleAssets;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.notes.tangible.TangibleAssetsColumns;
 
-@Mapper
+@RequestScope
+@Mapper(componentModel = "spring")
 public interface ApiToTangibleAssetsNoteMapper {
-
-    ApiToTangibleAssetsNoteMapper INSTANCE = Mappers.getMapper(ApiToTangibleAssetsNoteMapper.class);
 
     @Mappings({
             @Mapping(source = "tangible.fixturesAndFittings.cost.additions",

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapper.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapper.java
@@ -4,15 +4,14 @@ import org.mapstruct.DecoratedWith;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
-import org.mapstruct.factory.Mappers;
+import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.SmallFullApiData;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.SmallFullAccountIxbrl;
 
-@Mapper
+@RequestScope
+@Mapper(componentModel = "spring")
 @DecoratedWith(SmallFullIXBRLMapperDecorator.class)
 public interface SmallFullIXBRLMapper {
-
-    SmallFullIXBRLMapper INSTANCE = Mappers.getMapper(SmallFullIXBRLMapper.class);
 
     @Mappings({
             @Mapping(source = "smallFullApiData.approval.name", target = "approvalName")

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mappers;
 
 import java.time.LocalDate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import uk.gov.companieshouse.accountsdates.AccountsDatesHelper;
 import uk.gov.companieshouse.accountsdates.impl.AccountsDatesHelperImpl;
 import uk.gov.companieshouse.api.model.accounts.smallfull.AccountingPoliciesApi;
@@ -29,13 +31,38 @@ import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model
 
 public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMapper {
 
-    private final SmallFullIXBRLMapper smallFullIXBRLMapper;
+    @Autowired
+    @Qualifier("delegate")
+    private SmallFullIXBRLMapper smallFullIXBRLMapper;
+
+    @Autowired
+    private ApiToCompanyMapper apiToCompanyMapper;
+
+    @Autowired
+    private ApiToPeriodMapper apiToPeriodMapper;
+
+    @Autowired
+    private ApiToBalanceSheetMapper apiToBalanceSheetMapper;
+
+    @Autowired
+    private ApiToAccountingPoliciesMapper apiToAccountingPoliciesMapper;
+
+    @Autowired
+    private ApiToStocksMapper apiToStocksMapper;
+
+    @Autowired
+    private ApiToDebtorsMapper apiToDebtorsMapper;
+
+    @Autowired
+    private ApiToCreditorsWithinOneYearMapper apiToCreditorsWithinOneYearMapper;
+
+    @Autowired
+    private ApiToCreditorsAfterOneYearMapper apiToCreditorsAfterOneYearMapper;
+
+    @Autowired
+    private ApiToTangibleAssetsNoteMapper apiToTangibleAssetsNoteMapper;
 
     private AccountsDatesHelper accountsDatesHelper = new AccountsDatesHelperImpl();
-
-    public SmallFullIXBRLMapperDecorator(SmallFullIXBRLMapper smallFullIXBRLMapper) {
-        this.smallFullIXBRLMapper = smallFullIXBRLMapper;
-    }
 
     @Override
     public SmallFullAccountIxbrl mapSmallFullIXBRLModel(SmallFullApiData smallFullApiData) {
@@ -46,8 +73,8 @@ public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMap
                 setBalanceSheet(smallFullApiData.getCurrentPeriod(),
                         smallFullApiData.getPreviousPeriod(),
                         smallFullApiData.getBalanceSheetStatements()));
-        smallFullAccountIxbrl.setCompany(ApiToCompanyMapper.INSTANCE.apiToCompany(smallFullApiData.getCompanyProfile()));
-        smallFullAccountIxbrl.setPeriod(ApiToPeriodMapper.INSTANCE.apiToPeriod(smallFullApiData.getCompanyProfile()));
+        smallFullAccountIxbrl.setCompany(apiToCompanyMapper.apiToCompany(smallFullApiData.getCompanyProfile()));
+        smallFullAccountIxbrl.setPeriod(apiToPeriodMapper.apiToPeriod(smallFullApiData.getCompanyProfile()));
 
         if (smallFullApiData.getApproval() != null && smallFullApiData.getApproval().getDate() != null) {
             smallFullAccountIxbrl.setApprovalDate(convertToDisplayDate(smallFullApiData.getApproval().getDate()));
@@ -121,24 +148,24 @@ public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMap
 
         if (currentPeriod.getBalanceSheet() != null) {
             if (currentPeriod.getBalanceSheet().getCalledUpShareCapitalNotPaid() != null) {
-                balanceSheet.setCalledUpSharedCapitalNotPaid(ApiToBalanceSheetMapper.INSTANCE.apiToCalledUpSharedCapitalNotPaid(currentPeriod, previousPeriod));
+                balanceSheet.setCalledUpSharedCapitalNotPaid(apiToBalanceSheetMapper.apiToCalledUpSharedCapitalNotPaid(currentPeriod, previousPeriod));
             }
             if (currentPeriod.getBalanceSheet().getOtherLiabilitiesOrAssets() != null) {
-                balanceSheet.setOtherLiabilitiesOrAssets(ApiToBalanceSheetMapper.INSTANCE.apiToOtherLiabilitiesOrAssets(currentPeriod, previousPeriod));
+                balanceSheet.setOtherLiabilitiesOrAssets(apiToBalanceSheetMapper.apiToOtherLiabilitiesOrAssets(currentPeriod, previousPeriod));
             }
             if (currentPeriod.getBalanceSheet().getFixedAssets() != null) {
-                balanceSheet.setFixedAssets(ApiToBalanceSheetMapper.INSTANCE.apiToFixedAssets(currentPeriod, previousPeriod));
+                balanceSheet.setFixedAssets(apiToBalanceSheetMapper.apiToFixedAssets(currentPeriod, previousPeriod));
             }
             if (currentPeriod.getBalanceSheet().getCurrentAssets() != null) {
-                balanceSheet.setCurrentAssets(ApiToBalanceSheetMapper.INSTANCE.apiToCurrentAssets(currentPeriod, previousPeriod));
+                balanceSheet.setCurrentAssets(apiToBalanceSheetMapper.apiToCurrentAssets(currentPeriod, previousPeriod));
             }
             if (currentPeriod.getBalanceSheet().getCapitalAndReserves() != null) {
-                balanceSheet.setCapitalAndReserve(ApiToBalanceSheetMapper.INSTANCE.apiToCapitalAndReserve(currentPeriod, previousPeriod));
+                balanceSheet.setCapitalAndReserve(apiToBalanceSheetMapper.apiToCapitalAndReserve(currentPeriod, previousPeriod));
             }
         }
 
         if (balanceSheetStatements != null) {
-            balanceSheet.setBalanceSheetStatements(ApiToBalanceSheetMapper.INSTANCE.apiToStatements(balanceSheetStatements));
+            balanceSheet.setBalanceSheetStatements(apiToBalanceSheetMapper.apiToStatements(balanceSheetStatements));
         }
 
         return balanceSheet;
@@ -146,41 +173,41 @@ public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMap
 
     private AccountingPolicies mapAccountingPolicies(AccountingPoliciesApi accountingPolicies) {
 
-        return ApiToAccountingPoliciesMapper.INSTANCE
+        return apiToAccountingPoliciesMapper
                 .apiToAccountingPolicies(accountingPolicies);
     }
 
     private StocksNote mapStocks(StocksApi stocks) {
 
-        return ApiToStocksMapper.INSTANCE
+        return apiToStocksMapper
                 .apiToStocks(stocks.getCurrentPeriod(),
                         stocks.getPreviousPeriod());
     }
     
     private Debtors mapDebtors(DebtorsApi debtors) {
 
-        return ApiToDebtorsMapper.INSTANCE
+        return apiToDebtorsMapper
                 .apiToDebtors(debtors.getDebtorsCurrentPeriod(),
                         debtors.getDebtorsPreviousPeriod());
     }
     
     private CreditorsWithinOneYear mapCreditorsWithinOneYear(CreditorsWithinOneYearApi creditorsWithinOneYearApi) {
 
-        return ApiToCreditorsWithinOneYearMapper.INSTANCE
+        return apiToCreditorsWithinOneYearMapper
                 .apiToCreditorsWithinOneYear(creditorsWithinOneYearApi.getCreditorsWithinOneYearCurrentPeriod(),
                         creditorsWithinOneYearApi.getCreditorsWithinOneYearPreviousPeriod());
     }
     
     private CreditorsAfterOneYear mapCreditorsAfterOneYear(CreditorsAfterOneYearApi creditorsAfterOneYearApi) {
 
-        return ApiToCreditorsAfterOneYearMapper.INSTANCE
+        return apiToCreditorsAfterOneYearMapper
                 .apiToCreditorsAfterOneYear(creditorsAfterOneYearApi.getCurrentPeriod(),
                         creditorsAfterOneYearApi.getPreviousPeriod());
     }
 
     private TangibleAssets mapTangibleAssets(TangibleApi tangible) {
 
-        TangibleAssets tangibleAssets = ApiToTangibleAssetsNoteMapper.INSTANCE.apiToTangibleAssetsNoteAdditionalInformation(tangible);
+        TangibleAssets tangibleAssets = apiToTangibleAssetsNoteMapper.apiToTangibleAssetsNoteAdditionalInformation(tangible);
 
         tangibleAssets.setCost(mapTangibleAssetsCost(tangible));
         tangibleAssets.setDepreciation(mapTangibleAssetsDepreciation(tangible));
@@ -193,12 +220,12 @@ public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMap
 
         TangibleAssetsCost cost = new TangibleAssetsCost();
 
-        cost.setAdditions(ApiToTangibleAssetsNoteMapper.INSTANCE.apiToTangibleAssetsCostAdditionsMapper(tangible));
-        cost.setAtPeriodEnd(ApiToTangibleAssetsNoteMapper.INSTANCE.apiToTangibleAssetsCostAtPeriodEndMapper(tangible));
-        cost.setAtPeriodStart(ApiToTangibleAssetsNoteMapper.INSTANCE.apiToTangibleAssetsCostAtPeriodStartMapper(tangible));
-        cost.setDisposals(ApiToTangibleAssetsNoteMapper.INSTANCE.apiToTangibleAssetsCostDisposalsMapper(tangible));
-        cost.setRevaluations(ApiToTangibleAssetsNoteMapper.INSTANCE.apiToTangibleAssetsCostRevaluationsMapper(tangible));
-        cost.setTransfers(ApiToTangibleAssetsNoteMapper.INSTANCE.apiToTangibleAssetsCostTransfersMapper(tangible));
+        cost.setAdditions(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostAdditionsMapper(tangible));
+        cost.setAtPeriodEnd(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostAtPeriodEndMapper(tangible));
+        cost.setAtPeriodStart(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostAtPeriodStartMapper(tangible));
+        cost.setDisposals(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostDisposalsMapper(tangible));
+        cost.setRevaluations(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostRevaluationsMapper(tangible));
+        cost.setTransfers(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostTransfersMapper(tangible));
 
         return cost;
     }
@@ -207,15 +234,15 @@ public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMap
 
         TangibleAssetsDepreciation depreciation = new TangibleAssetsDepreciation();
 
-        depreciation.setAtPeriodEnd(ApiToTangibleAssetsNoteMapper.INSTANCE
+        depreciation.setAtPeriodEnd(apiToTangibleAssetsNoteMapper
                 .apiToTangibleAssetsDepreciationAtPeriodEndMapper(tangible));
-        depreciation.setAtPeriodStart(ApiToTangibleAssetsNoteMapper.INSTANCE
+        depreciation.setAtPeriodStart(apiToTangibleAssetsNoteMapper
                 .apiToTangibleAssetsDepreciationAtPeriodStartMapper(tangible));
-        depreciation.setChargeForYear(ApiToTangibleAssetsNoteMapper.INSTANCE
+        depreciation.setChargeForYear(apiToTangibleAssetsNoteMapper
                 .apiToTangibleAssetsDepreciationChargeForYearMapper(tangible));
-        depreciation.setOnDisposals(ApiToTangibleAssetsNoteMapper.INSTANCE
+        depreciation.setOnDisposals(apiToTangibleAssetsNoteMapper
                 .apiToTangibleAssetsDepreciationOnDisposalsMapper(tangible));
-        depreciation.setOtherAdjustments(ApiToTangibleAssetsNoteMapper.INSTANCE
+        depreciation.setOtherAdjustments(apiToTangibleAssetsNoteMapper
                 .apiToTangibleAssetsDepreciationOtherAdjustmentsMapper(tangible));
 
         return depreciation;
@@ -225,9 +252,9 @@ public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMap
 
         TangibleAssetsNetBookValue netBookValue = new TangibleAssetsNetBookValue();
 
-        netBookValue.setCurrentPeriod(ApiToTangibleAssetsNoteMapper.INSTANCE
+        netBookValue.setCurrentPeriod(apiToTangibleAssetsNoteMapper
                 .apiToTangibleAssetsNetBookValueCurrentPeriodMapper(tangible));
-        netBookValue.setPreviousPeriod(ApiToTangibleAssetsNoteMapper.INSTANCE
+        netBookValue.setPreviousPeriod(apiToTangibleAssetsNoteMapper
                 .apiToTangibleAssetsNetBookValuePreviousPeriodMapper(tangible));
 
         return netBookValue;

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
@@ -32,7 +32,7 @@ import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model
 public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMapper {
 
     @Autowired
-    @Qualifier("smallFullIXBRLMapper")
+    @Qualifier("delegate")
     private SmallFullIXBRLMapper smallFullIXBRLMapper;
 
     @Autowired

--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
@@ -32,7 +32,7 @@ import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model
 public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMapper {
 
     @Autowired
-    @Qualifier("delegate")
+    @Qualifier("smallFullIXBRLMapper")
     private SmallFullIXBRLMapper smallFullIXBRLMapper;
 
     @Autowired

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToAccountingPoliciesMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToAccountingPoliciesMapperTest.java
@@ -15,6 +15,8 @@ import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ApiToAccountingPoliciesMapperTest {
 
+    private ApiToAccountingPoliciesMapper apiToAccountingPoliciesMapper = new ApiToAccountingPoliciesMapperImpl();
+
     private static final String BASIS_OF_PREPARATION = "basisOfPreparation";
 
     private static final String TURNOVER_POLICY = "turnoverPolicy";
@@ -31,7 +33,7 @@ public class ApiToAccountingPoliciesMapperTest {
     @DisplayName("tests accounting policies API values map to accounting policies IXBRL model")
     void testApiToCompanyMaps() {
 
-        AccountingPolicies accountingPolicies = ApiToAccountingPoliciesMapper.INSTANCE.apiToAccountingPolicies(createAccountingPolicies());
+        AccountingPolicies accountingPolicies = apiToAccountingPoliciesMapper.apiToAccountingPolicies(createAccountingPolicies());
 
         assertNotNull(accountingPolicies);
         assertEquals(BASIS_OF_PREPARATION, accountingPolicies.getBasisOfMeasurementAndPreparation());

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToBalanceSheetMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToBalanceSheetMapperTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mappers;
 
-import org.apache.http.cookie.SM;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -29,6 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ApiToBalanceSheetMapperTest {
 
+    private ApiToBalanceSheetMapper apiToBalanceSheetMapper = new ApiToBalanceSheetMapperImpl();
+
     private static final Long VALUE_ONE = 100L;
 
     private static final Long VALUE_TWO = 200L;
@@ -47,7 +48,7 @@ public class ApiToBalanceSheetMapperTest {
     @DisplayName("tests that both current and previous period values map to capital and reserve IXBRL model")
     void testApiToCapitalReserveMapsCurrentAndPrevious() {
 
-        CapitalAndReserve capitalAndReserve = ApiToBalanceSheetMapper.INSTANCE.apiToCapitalAndReserve(createCurrentPeriod(), createPreviousPeriod());
+        CapitalAndReserve capitalAndReserve = apiToBalanceSheetMapper.apiToCapitalAndReserve(createCurrentPeriod(), createPreviousPeriod());
 
         assertNotNull(capitalAndReserve);
         assertEquals(new Long(VALUE_ONE), capitalAndReserve.getCalledUpShareCapital().getCurrentAmount());
@@ -66,7 +67,7 @@ public class ApiToBalanceSheetMapperTest {
     @DisplayName("tests that current period values map to capital and reserve IXBRL model")
     void testApiToCapitalReserveMapsCurrentOnly() {
 
-        CapitalAndReserve capitalAndReserve = ApiToBalanceSheetMapper.INSTANCE.apiToCapitalAndReserve(createCurrentPeriod(), null);
+        CapitalAndReserve capitalAndReserve = apiToBalanceSheetMapper.apiToCapitalAndReserve(createCurrentPeriod(), null);
 
         assertNotNull(capitalAndReserve);
         assertEquals(new Long(VALUE_ONE), capitalAndReserve.getCalledUpShareCapital().getCurrentAmount());
@@ -80,7 +81,7 @@ public class ApiToBalanceSheetMapperTest {
     @DisplayName("tests that both current and previous period values map to current assets IXBRL model")
     void testApiToCurrentAssetsMapsCurrentAndPrevious() {
 
-        CurrentAssets currentAssets = ApiToBalanceSheetMapper.INSTANCE.apiToCurrentAssets(createCurrentPeriod(), createPreviousPeriod());
+        CurrentAssets currentAssets = apiToBalanceSheetMapper.apiToCurrentAssets(createCurrentPeriod(), createPreviousPeriod());
 
         assertNotNull(currentAssets);
         assertEquals(new Long(VALUE_ONE), currentAssets.getCashAtBankAndInHand().getCurrentAmount());
@@ -97,7 +98,7 @@ public class ApiToBalanceSheetMapperTest {
     @DisplayName("tests that current period values mapped to current assets IXBRL model")
     void testApiToCurrentAssetsMapsCurrentOnly() {
 
-        CurrentAssets currentAssets = ApiToBalanceSheetMapper.INSTANCE.apiToCurrentAssets(createCurrentPeriod(), null);
+        CurrentAssets currentAssets = apiToBalanceSheetMapper.apiToCurrentAssets(createCurrentPeriod(), null);
 
         assertNotNull(currentAssets);
         assertEquals(new Long(VALUE_ONE), currentAssets.getCashAtBankAndInHand().getCurrentAmount());
@@ -110,7 +111,7 @@ public class ApiToBalanceSheetMapperTest {
     @DisplayName("tests that the current and previous period values map to fixed assets IXBRL model")
     void testApiToFixedAssetsMapsCurrentAndPrevious() {
 
-        FixedAssets fixedAssets = ApiToBalanceSheetMapper.INSTANCE.apiToFixedAssets(createCurrentPeriod(), createPreviousPeriod());
+        FixedAssets fixedAssets = apiToBalanceSheetMapper.apiToFixedAssets(createCurrentPeriod(), createPreviousPeriod());
 
         assertNotNull(fixedAssets);
         assertEquals(new Long(VALUE_ONE), fixedAssets.getTangibleAssets().getCurrentAmount());
@@ -123,7 +124,7 @@ public class ApiToBalanceSheetMapperTest {
     @DisplayName("tests that the current period values map to fixed assets IXBRL model")
     void testApiToFixedAssetsMapsCurrentOnly() {
 
-        FixedAssets fixedAssets = ApiToBalanceSheetMapper.INSTANCE.apiToFixedAssets(createCurrentPeriod(), null);
+        FixedAssets fixedAssets = apiToBalanceSheetMapper.apiToFixedAssets(createCurrentPeriod(), null);
 
         assertNotNull(fixedAssets);
         assertEquals(new Long(VALUE_ONE), fixedAssets.getTangibleAssets().getCurrentAmount());
@@ -134,7 +135,7 @@ public class ApiToBalanceSheetMapperTest {
     @DisplayName("tests that the current and previous period values map to other liabilities or assets IXBRL model")
     void testApiToOtherLiabilitiesOrAssetsMapsCurrentAndPrevious() {
 
-        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = ApiToBalanceSheetMapper.INSTANCE.apiToOtherLiabilitiesOrAssets(
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = apiToBalanceSheetMapper.apiToOtherLiabilitiesOrAssets(
                 createCurrentPeriod(), createPreviousPeriod());
 
         assertNotNull(otherLiabilitiesOrAssets);
@@ -161,7 +162,7 @@ public class ApiToBalanceSheetMapperTest {
     @DisplayName("tests that the current period values map to other liabilities or assets IXBRL model")
     void testApiToOtherLiabilitiesOrAssetsMapsCurrentOnly() {
 
-        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = ApiToBalanceSheetMapper.INSTANCE.apiToOtherLiabilitiesOrAssets(
+        OtherLiabilitiesOrAssets otherLiabilitiesOrAssets = apiToBalanceSheetMapper.apiToOtherLiabilitiesOrAssets(
                 createCurrentPeriod(), null);
 
         assertNotNull(otherLiabilitiesOrAssets);
@@ -179,8 +180,8 @@ public class ApiToBalanceSheetMapperTest {
     @DisplayName("tests that the current and previous period values map to called up share capital not paid IXBRL model")
     void testApiToCalledUpShareCapitalNotPaidMapsCurrentAndPrevious() {
 
-        CalledUpSharedCapitalNotPaid calledUpSharedCapitalNotPaid = ApiToBalanceSheetMapper
-                .INSTANCE.apiToCalledUpSharedCapitalNotPaid(createCurrentPeriod(), createPreviousPeriod());
+        CalledUpSharedCapitalNotPaid calledUpSharedCapitalNotPaid = apiToBalanceSheetMapper
+                .apiToCalledUpSharedCapitalNotPaid(createCurrentPeriod(), createPreviousPeriod());
 
         assertNotNull(calledUpSharedCapitalNotPaid);
         assertEquals(new Long(VALUE_ONE), calledUpSharedCapitalNotPaid.getCurrentAmount());
@@ -191,8 +192,8 @@ public class ApiToBalanceSheetMapperTest {
     @DisplayName("tests that the current period values map to called up share capital not paid IXBRL model")
     void testApiToCalledUpShareCapitalNotPaidMapsCurrentOnly() {
 
-        CalledUpSharedCapitalNotPaid calledUpSharedCapitalNotPaid = ApiToBalanceSheetMapper
-                .INSTANCE.apiToCalledUpSharedCapitalNotPaid(createCurrentPeriod(), null);
+        CalledUpSharedCapitalNotPaid calledUpSharedCapitalNotPaid = apiToBalanceSheetMapper
+                .apiToCalledUpSharedCapitalNotPaid(createCurrentPeriod(), null);
 
         assertNotNull(calledUpSharedCapitalNotPaid);
         assertEquals(new Long(VALUE_ONE), calledUpSharedCapitalNotPaid.getCurrentAmount());
@@ -203,7 +204,7 @@ public class ApiToBalanceSheetMapperTest {
     void testApiToBalanceSheetStatementsMapsCorrectly() {
 
         BalanceSheetStatements balanceSheetStatements =
-                ApiToBalanceSheetMapper.INSTANCE.apiToStatements(createBalanceSheetStatements());
+                apiToBalanceSheetMapper.apiToStatements(createBalanceSheetStatements());
 
         assertNotNull(balanceSheetStatements);
         assertEquals(SECTION_477, balanceSheetStatements.getSection477());

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCompanyMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCompanyMapperTest.java
@@ -15,6 +15,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ApiToCompanyMapperTest {
 
+    private ApiToCompanyMapper apiToCompanyMapper = new ApiToCompanyMapperImpl();
+
     private static final String JURISDICTION = "jurisdiction";
 
     private static final String COMPANY_NAME = "companyName";
@@ -25,7 +27,7 @@ public class ApiToCompanyMapperTest {
     @DisplayName("tests company values map to company IXBRL model")
     void testApiToCompanyMaps() {
 
-        Company company = ApiToCompanyMapper.INSTANCE.apiToCompany(createCompanyProfile());
+        Company company = apiToCompanyMapper.apiToCompany(createCompanyProfile());
 
         assertNotNull(company);
         assertEquals(COMPANY_NAME, company.getCompanyName());

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCreditorsAfterOneYearMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCreditorsAfterOneYearMapperTest.java
@@ -17,6 +17,9 @@ import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ApiToCreditorsAfterOneYearMapperTest {
 
+    private ApiToCreditorsAfterOneYearMapper apiToCreditorsAfterOneYearMapper =
+            new ApiToCreditorsAfterOneYearMapperImpl();
+
     private static final String DETAILS = "Details";
     
     private static final Long BANK_LOANS_AND_OVERDRAFTS_CURRENT = 1L;
@@ -32,7 +35,7 @@ public class ApiToCreditorsAfterOneYearMapperTest {
     @DisplayName("tests populated creditors after one year API maps to creditors after one year IXBRL model")
     void testApiToCreditorsMaps() {
 
-        CreditorsAfterOneYear creditorsAfterOneYear = ApiToCreditorsAfterOneYearMapper.INSTANCE.apiToCreditorsAfterOneYear(createCurrentPeriodCreditorsAfterOneYear(),
+        CreditorsAfterOneYear creditorsAfterOneYear = apiToCreditorsAfterOneYearMapper.apiToCreditorsAfterOneYear(createCurrentPeriodCreditorsAfterOneYear(),
                 createPreviousPeriodCreditorsAfterOneYear());
 
         assertNotNull(creditorsAfterOneYear);
@@ -52,7 +55,7 @@ public class ApiToCreditorsAfterOneYearMapperTest {
     @DisplayName("tests creditors after one year API with null previous period maps to null creditors after one year IXBRL model")
     void testApiToCreditorsMapsWhenPreviousPeriodsNull() {
 
-        CreditorsAfterOneYear creditorsAfterOneYear = ApiToCreditorsAfterOneYearMapper.INSTANCE.apiToCreditorsAfterOneYear(createCurrentPeriodCreditorsAfterOneYear(),
+        CreditorsAfterOneYear creditorsAfterOneYear = apiToCreditorsAfterOneYearMapper.apiToCreditorsAfterOneYear(createCurrentPeriodCreditorsAfterOneYear(),
                 null);
 
         assertNotNull(creditorsAfterOneYear);
@@ -72,7 +75,7 @@ public class ApiToCreditorsAfterOneYearMapperTest {
     @DisplayName("tests creditors after one year API with null current period maps to null creditors after one year IXBRL model")
     void testApiToCreditorsMapsWhenCurrentPeriodsNull() {
 
-        CreditorsAfterOneYear creditorsAfterOneYear = ApiToCreditorsAfterOneYearMapper.INSTANCE.apiToCreditorsAfterOneYear(null,
+        CreditorsAfterOneYear creditorsAfterOneYear = apiToCreditorsAfterOneYearMapper.apiToCreditorsAfterOneYear(null,
                 createPreviousPeriodCreditorsAfterOneYear());
 
         assertNotNull(creditorsAfterOneYear);
@@ -92,7 +95,7 @@ public class ApiToCreditorsAfterOneYearMapperTest {
     @DisplayName("tests creditors after one year API with null periods maps to null creditors after one year IXBRL model")
     void testApiToCreditorsMapsWhenBothPeriodsNull() {
 
-        CreditorsAfterOneYear creditorsAfterOneYear = ApiToCreditorsAfterOneYearMapper.INSTANCE.apiToCreditorsAfterOneYear(null, null);
+        CreditorsAfterOneYear creditorsAfterOneYear = apiToCreditorsAfterOneYearMapper.apiToCreditorsAfterOneYear(null, null);
 
         assertNull(creditorsAfterOneYear);
     }

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCreditorsWithinOneYearMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToCreditorsWithinOneYearMapperTest.java
@@ -17,6 +17,9 @@ import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ApiToCreditorsWithinOneYearMapperTest {
 
+    private ApiToCreditorsWithinOneYearMapper apiToCreditorsWithinOneYearMapper =
+            new ApiToCreditorsWithinOneYearMapperImpl();
+
     private static final String DETAILS = "Details";
     
     private static final Long ACCRUALS_AND_DEFERRED_INCOME_CURRENT = 1L;
@@ -38,7 +41,7 @@ public class ApiToCreditorsWithinOneYearMapperTest {
     @DisplayName("tests populated creditors within one year API maps to creditors within one year IXBRL model")
     void testApiToCreditorsMaps() {
 
-        CreditorsWithinOneYear creditorsWithinOneYear = ApiToCreditorsWithinOneYearMapper.INSTANCE.apiToCreditorsWithinOneYear(createCurrentPeriodCreditorsWithinOneYear(),
+        CreditorsWithinOneYear creditorsWithinOneYear = apiToCreditorsWithinOneYearMapper.apiToCreditorsWithinOneYear(createCurrentPeriodCreditorsWithinOneYear(),
                 createPreviousPeriodCreditorsWithinOneYear());
 
         assertNotNull(creditorsWithinOneYear);
@@ -64,7 +67,7 @@ public class ApiToCreditorsWithinOneYearMapperTest {
     @DisplayName("tests creditors within one year API with null previous period maps to creditors within one year IXBRL model")
     void testApiToCreditorsMapsWhenPreviousPeriodsNull() {
 
-        CreditorsWithinOneYear creditorsWithinOneYear = ApiToCreditorsWithinOneYearMapper.INSTANCE.apiToCreditorsWithinOneYear(createCurrentPeriodCreditorsWithinOneYear(),
+        CreditorsWithinOneYear creditorsWithinOneYear = apiToCreditorsWithinOneYearMapper.apiToCreditorsWithinOneYear(createCurrentPeriodCreditorsWithinOneYear(),
                 null);
 
         assertNotNull(creditorsWithinOneYear);
@@ -90,7 +93,7 @@ public class ApiToCreditorsWithinOneYearMapperTest {
     @DisplayName("tests creditors within one year API with null current period maps to creditors within one year IXBRL model")
     void testApiToCreditorsMapsWhenCurrentPeriodsNull() {
 
-        CreditorsWithinOneYear creditorsWithinOneYear = ApiToCreditorsWithinOneYearMapper.INSTANCE.apiToCreditorsWithinOneYear(null,
+        CreditorsWithinOneYear creditorsWithinOneYear = apiToCreditorsWithinOneYearMapper.apiToCreditorsWithinOneYear(null,
                 createPreviousPeriodCreditorsWithinOneYear());
 
         assertNotNull(creditorsWithinOneYear);
@@ -116,7 +119,7 @@ public class ApiToCreditorsWithinOneYearMapperTest {
     @DisplayName("tests creditors within one year API with null periods maps to null creditors within one year IXBRL model")
     void testApiToCreditorsMapsWhenBothPeriodsNull() {
 
-        CreditorsWithinOneYear creditorsWithinOneYear = ApiToCreditorsWithinOneYearMapper.INSTANCE.apiToCreditorsWithinOneYear(null, null);
+        CreditorsWithinOneYear creditorsWithinOneYear = apiToCreditorsWithinOneYearMapper.apiToCreditorsWithinOneYear(null, null);
 
         assertNull(creditorsWithinOneYear);
     }

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToDebtorsMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToDebtorsMapperTest.java
@@ -12,10 +12,11 @@ import uk.gov.companieshouse.api.model.accounts.smallfull.Debtors.CurrentPeriod;
 import uk.gov.companieshouse.api.model.accounts.smallfull.Debtors.PreviousPeriod;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.debtors.Debtors;
 
-
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ApiToDebtorsMapperTest {
+
+    private ApiToDebtorsMapper apiToDebtorsMapper = new ApiToDebtorsMapperImpl();
 
     private static final String DETAILS = "Details";
     private static final Long GREATER_THAN_ONE_YEAR_CURRENT = 1L;
@@ -33,7 +34,7 @@ public class ApiToDebtorsMapperTest {
     @DisplayName("tests debtors API values map to debtors IXBRL model")
     void testApiToCompanyMaps() {
 
-        Debtors debtors = ApiToDebtorsMapper.INSTANCE.apiToDebtors(createCurrentPeriodDebtors(),
+        Debtors debtors = apiToDebtorsMapper.apiToDebtors(createCurrentPeriodDebtors(),
                 createPreviousPeriodDebtors());
 
         assertNotNull(debtors);

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToPeriodMapperTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.company.account.CompanyAccountApi;
 import uk.gov.companieshouse.api.model.company.account.LastAccountsApi;
@@ -19,6 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ApiToPeriodMapperTest {
+
+    @Autowired
+    private ApiToPeriodMapper apiToPeriodMapper;
 
     private static final String CURRENT_PERIOD_START_ON = "2018-01-01";
 
@@ -44,7 +48,7 @@ public class ApiToPeriodMapperTest {
     @DisplayName("tests that the dates from Api are mapped to Period IXBRL model for multi year filings")
     void testApiMapsDatesToPeriodModelForMultiYearFiling() {
 
-        Period period = ApiToPeriodMapper.INSTANCE.apiToPeriod(createAccountsFilingDates(true));
+        Period period = apiToPeriodMapper.apiToPeriod(createAccountsFilingDates(true));
 
         assertNotNull(period);
         assertEquals(CURRENT_PERIOD_START_ON, period.getCurrentPeriodStartOn());
@@ -63,7 +67,7 @@ public class ApiToPeriodMapperTest {
     @DisplayName("tests that the dates from Api are mapped to Period IXBRL model for single year filings")
     void testApiMapsDatesToPeriodModelForSingleYearFiling() {
 
-        Period period = ApiToPeriodMapper.INSTANCE.apiToPeriod(createAccountsFilingDates(false));
+        Period period = apiToPeriodMapper.apiToPeriod(createAccountsFilingDates(false));
 
         assertNotNull(period);
         assertEquals(CURRENT_PERIOD_START_ON, period.getCurrentPeriodStartOn());

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToStocksMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToStocksMapperTest.java
@@ -10,14 +10,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.model.accounts.smallfull.stocks.CurrentPeriod;
 import uk.gov.companieshouse.api.model.accounts.smallfull.stocks.PreviousPeriod;
-import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.creditorswithinoneyear.CreditorsWithinOneYear;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.stocks.StocksNote;
-
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ApiToStocksMapperTest {
 
+    private ApiToStocksMapper apiToStocksMapper = new ApiToStocksMapperImpl();
 
     private static final Long STOCKS_CURRENT = 1L;
     private static final Long STOCKS_PREVIOUS = 10L;
@@ -30,7 +29,7 @@ public class ApiToStocksMapperTest {
     @DisplayName("tests stocks API values map to stocks IXBRL model")
     void testApiToCompanyMaps() {
 
-        StocksNote stocks = ApiToStocksMapper.INSTANCE.apiToStocks(createCurrentPeriodStocks(),
+        StocksNote stocks = apiToStocksMapper.apiToStocks(createCurrentPeriodStocks(),
                 createPreviousPeriodStocks());
 
         assertNotNull(stocks);
@@ -47,7 +46,7 @@ public class ApiToStocksMapperTest {
     @DisplayName("tests stocks API with null previous period maps to stocks IXBRL model")
     void testApiToCreditorsMapsWhenPreviousPeriodsNull() {
 
-        StocksNote stocks = ApiToStocksMapper.INSTANCE.apiToStocks(createCurrentPeriodStocks(), null);
+        StocksNote stocks = apiToStocksMapper.apiToStocks(createCurrentPeriodStocks(), null);
 
         assertNotNull(stocks);
         
@@ -63,7 +62,7 @@ public class ApiToStocksMapperTest {
     @DisplayName("tests stocks API with null current period maps to stocks IXBRL model")
     void testApiToCreditorsMapsWhenCurrentPeriodsNull() {
 
-        StocksNote stocks = ApiToStocksMapper.INSTANCE.apiToStocks(null, createPreviousPeriodStocks());
+        StocksNote stocks = apiToStocksMapper.apiToStocks(null, createPreviousPeriodStocks());
 
         assertNotNull(stocks);
         assertEquals(null, stocks.getStocks().getCurrentAmount());
@@ -100,7 +99,7 @@ public class ApiToStocksMapperTest {
     @DisplayName("tests stocks API with null periods maps to null stocks IXBRL model")
     void testApiToCreditorsMapsWhenBothPeriodsNull() {
 
-        StocksNote stocksNote = ApiToStocksMapper.INSTANCE.apiToStocks(null, null);
+        StocksNote stocksNote = apiToStocksMapper.apiToStocks(null, null);
 
         assertNull(stocksNote);
     }

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToTangibleAssetsNoteMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/ApiToTangibleAssetsNoteMapperTest.java
@@ -16,6 +16,9 @@ import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model
 
 public class ApiToTangibleAssetsNoteMapperTest {
 
+    private ApiToTangibleAssetsNoteMapper apiToTangibleAssetsNoteMapper =
+            new ApiToTangibleAssetsNoteMapperImpl();
+
     @Test
     @DisplayName("test cost additions API values map to iXBRL model")
     public void testCostAdditionsAPIToIXBRL() {
@@ -24,7 +27,7 @@ public class ApiToTangibleAssetsNoteMapperTest {
         TangibleAssets tangible = new TangibleAssets();
         TangibleAssetsCost cost = new TangibleAssetsCost();
 
-        cost.setAdditions(ApiToTangibleAssetsNoteMapper.INSTANCE.apiToTangibleAssetsCostAdditionsMapper(tangibleApi));
+        cost.setAdditions(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostAdditionsMapper(tangibleApi));
 
         tangible.setCost(cost);
 
@@ -55,7 +58,7 @@ public class ApiToTangibleAssetsNoteMapperTest {
         TangibleAssets tangible = new TangibleAssets();
         TangibleAssetsCost cost = new TangibleAssetsCost();
 
-        cost.setAtPeriodEnd(ApiToTangibleAssetsNoteMapper.INSTANCE.apiToTangibleAssetsCostAtPeriodEndMapper(tangibleApi));
+        cost.setAtPeriodEnd(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostAtPeriodEndMapper(tangibleApi));
         tangible.setCost(cost);
 
         assertNotNull(tangible);
@@ -85,7 +88,7 @@ public class ApiToTangibleAssetsNoteMapperTest {
         TangibleAssets tangible = new TangibleAssets();
         TangibleAssetsCost cost = new TangibleAssetsCost();
 
-        cost.setAtPeriodStart(ApiToTangibleAssetsNoteMapper.INSTANCE.apiToTangibleAssetsCostAtPeriodStartMapper(tangibleApi));
+        cost.setAtPeriodStart(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostAtPeriodStartMapper(tangibleApi));
         tangible.setCost(cost);
 
         assertNotNull(tangible);
@@ -115,7 +118,7 @@ public class ApiToTangibleAssetsNoteMapperTest {
         TangibleAssets tangible = new TangibleAssets();
         TangibleAssetsCost cost = new TangibleAssetsCost();
 
-        cost.setDisposals(ApiToTangibleAssetsNoteMapper.INSTANCE.apiToTangibleAssetsCostDisposalsMapper(tangibleApi));
+        cost.setDisposals(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostDisposalsMapper(tangibleApi));
         tangible.setCost(cost);
 
         assertNotNull(tangible);
@@ -145,7 +148,7 @@ public class ApiToTangibleAssetsNoteMapperTest {
         TangibleAssets tangible = new TangibleAssets();
         TangibleAssetsCost cost = new TangibleAssetsCost();
 
-        cost.setRevaluations(ApiToTangibleAssetsNoteMapper.INSTANCE.apiToTangibleAssetsCostRevaluationsMapper(tangibleApi));
+        cost.setRevaluations(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostRevaluationsMapper(tangibleApi));
         tangible.setCost(cost);
 
         assertNotNull(tangible);
@@ -175,7 +178,7 @@ public class ApiToTangibleAssetsNoteMapperTest {
         TangibleAssets tangible = new TangibleAssets();
         TangibleAssetsCost cost = new TangibleAssetsCost();
 
-        cost.setTransfers(ApiToTangibleAssetsNoteMapper.INSTANCE.apiToTangibleAssetsCostTransfersMapper(tangibleApi));
+        cost.setTransfers(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostTransfersMapper(tangibleApi));
         tangible.setCost(cost);
 
         assertNotNull(tangible);
@@ -205,7 +208,7 @@ public class ApiToTangibleAssetsNoteMapperTest {
         TangibleAssets tangible = new TangibleAssets();
         TangibleAssetsDepreciation depreciation = new TangibleAssetsDepreciation();
 
-        depreciation.setAtPeriodEnd(ApiToTangibleAssetsNoteMapper.INSTANCE
+        depreciation.setAtPeriodEnd(apiToTangibleAssetsNoteMapper
                 .apiToTangibleAssetsDepreciationAtPeriodEndMapper(tangibleApi));
         tangible.setDepreciation(depreciation);
 
@@ -236,7 +239,7 @@ public class ApiToTangibleAssetsNoteMapperTest {
         TangibleAssets tangible = new TangibleAssets();
         TangibleAssetsDepreciation depreciation = new TangibleAssetsDepreciation();
 
-        depreciation.setAtPeriodStart(ApiToTangibleAssetsNoteMapper.INSTANCE
+        depreciation.setAtPeriodStart(apiToTangibleAssetsNoteMapper
                 .apiToTangibleAssetsDepreciationAtPeriodStartMapper(tangibleApi));
         tangible.setDepreciation(depreciation);
 
@@ -267,7 +270,7 @@ public class ApiToTangibleAssetsNoteMapperTest {
         TangibleAssets tangible = new TangibleAssets();
         TangibleAssetsDepreciation depreciation = new TangibleAssetsDepreciation();
 
-        depreciation.setChargeForYear(ApiToTangibleAssetsNoteMapper.INSTANCE
+        depreciation.setChargeForYear(apiToTangibleAssetsNoteMapper
                 .apiToTangibleAssetsDepreciationChargeForYearMapper(tangibleApi));
         tangible.setDepreciation(depreciation);
 
@@ -298,7 +301,7 @@ public class ApiToTangibleAssetsNoteMapperTest {
         TangibleAssets tangible = new TangibleAssets();
         TangibleAssetsDepreciation depreciation = new TangibleAssetsDepreciation();
 
-        depreciation.setOnDisposals(ApiToTangibleAssetsNoteMapper.INSTANCE
+        depreciation.setOnDisposals(apiToTangibleAssetsNoteMapper
                 .apiToTangibleAssetsDepreciationOnDisposalsMapper(tangibleApi));
         tangible.setDepreciation(depreciation);
 
@@ -329,7 +332,7 @@ public class ApiToTangibleAssetsNoteMapperTest {
         TangibleAssets tangible = new TangibleAssets();
         TangibleAssetsDepreciation depreciation = new TangibleAssetsDepreciation();
 
-        depreciation.setOtherAdjustments(ApiToTangibleAssetsNoteMapper.INSTANCE
+        depreciation.setOtherAdjustments(apiToTangibleAssetsNoteMapper
                 .apiToTangibleAssetsDepreciationOtherAdjustmentsMapper(tangibleApi));
         tangible.setDepreciation(depreciation);
 
@@ -360,7 +363,7 @@ public class ApiToTangibleAssetsNoteMapperTest {
         TangibleAssets tangible = new TangibleAssets();
         TangibleAssetsNetBookValue netBookValue = new TangibleAssetsNetBookValue();
 
-        netBookValue.setCurrentPeriod(ApiToTangibleAssetsNoteMapper.INSTANCE
+        netBookValue.setCurrentPeriod(apiToTangibleAssetsNoteMapper
                 .apiToTangibleAssetsNetBookValueCurrentPeriodMapper(tangibleApi));
         tangible.setNetBookValue(netBookValue);
 
@@ -391,7 +394,7 @@ public class ApiToTangibleAssetsNoteMapperTest {
         TangibleAssets tangible = new TangibleAssets();
         TangibleAssetsNetBookValue netBookValue = new TangibleAssetsNetBookValue();
 
-        netBookValue.setPreviousPeriod(ApiToTangibleAssetsNoteMapper.INSTANCE
+        netBookValue.setPreviousPeriod(apiToTangibleAssetsNoteMapper
                 .apiToTangibleAssetsNetBookValuePreviousPeriodMapper(tangibleApi));
         tangible.setNetBookValue(netBookValue);
 
@@ -420,7 +423,7 @@ public class ApiToTangibleAssetsNoteMapperTest {
     public void testAdditionalInformationAPIToIXBRL() {
 
         TangibleApi tangibleApi = createTangibleAssets();
-        TangibleAssets tangible = ApiToTangibleAssetsNoteMapper.INSTANCE.apiToTangibleAssetsNoteAdditionalInformation(tangibleApi);
+        TangibleAssets tangible = apiToTangibleAssetsNoteMapper.apiToTangibleAssetsNoteAdditionalInformation(tangibleApi);
 
         assertNotNull(tangible);
 

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperTest.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mappers;
 
-import org.junit.jupiter.api.DisplayName;
+/*import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -510,4 +510,4 @@ public class SmallFullIXBRLMapperTest {
 
         return creditorsAfterOneYearApi;
     }    
-}
+}*/

--- a/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperTest.java
+++ b/document-generator-accounts/src/test/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperTest.java
@@ -1,12 +1,16 @@
 package uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.mappers;
 
-/*import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.accounts.smallfull.AccountingPoliciesApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.ApprovalApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.BalanceSheetApi;
+import uk.gov.companieshouse.api.model.accounts.smallfull.BalanceSheetStatementsApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.CapitalAndReservesApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentAssetsApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriodApi;
@@ -19,13 +23,12 @@ import uk.gov.companieshouse.api.model.accounts.smallfull.stocks.StocksApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.FixedAssetsApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.OtherLiabilitiesOrAssetsApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.PreviousPeriodApi;
+import uk.gov.companieshouse.api.model.accounts.smallfull.tangible.TangibleApi;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
-import uk.gov.companieshouse.api.model.company.account.CompanyAccountApi;
-import uk.gov.companieshouse.api.model.company.account.LastAccountsApi;
-import uk.gov.companieshouse.api.model.company.account.NextAccountsApi;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.SmallFullApiData;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.SmallFullAccountIxbrl;
-import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.balancesheet.BalanceSheet;
+import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.accountingpolicies.AccountingPolicies;
+import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.balancesheet.BalanceSheetStatements;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.balancesheet.CalledUpSharedCapitalNotPaid;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.balancesheet.capitalandreserves.CapitalAndReserve;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.balancesheet.currentassets.CurrentAssets;
@@ -36,448 +39,493 @@ import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.creditorswithinoneyear.CreditorsWithinOneYear;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.debtors.Debtors;
 import java.time.LocalDate;
-import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.notes.BalanceSheetNotes;
+import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.notes.tangible.TangibleAssets;
+import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.notes.tangible.TangibleAssetsColumns;
+import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.period.Period;
 import uk.gov.companieshouse.document.generator.accounts.mapping.smallfull.model.ixbrl.stocks.StocksNote;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SmallFullIXBRLMapperTest {
 
-    private static final  Long VALUE_ONE = 100L;
-    private static final  Long VALUE_TWO = 200L;
-    private static final  Long VALUE_THREE = 300L;
-    private static final String JURISDICTION = "jurisdiction";
-    private static final String COMPANY_NAME = "companyName";
-    private static final String COMPANY_NUMBER = "companyNumber";
     private static final String NAME = "name";
-    private static final String DETAILS = "details";
+
+    @Mock
+    private SmallFullIXBRLMapper internalSmallFullIXBRLMapper;
+
+    @Mock
+    private ApiToCompanyMapper apiToCompanyMapper;
+
+    @Mock
+    private ApiToPeriodMapper apiToPeriodMapper;
+
+    @Mock
+    private ApiToBalanceSheetMapper apiToBalanceSheetMapper;
+
+    @Mock
+    private ApiToAccountingPoliciesMapper apiToAccountingPoliciesMapper;
+
+    @Mock
+    private ApiToStocksMapper apiToStocksMapper;
+
+    @Mock
+    private ApiToDebtorsMapper apiToDebtorsMapper;
+
+    @Mock
+    private ApiToCreditorsWithinOneYearMapper apiToCreditorsWithinOneYearMapper;
+
+    @Mock
+    private ApiToCreditorsAfterOneYearMapper apiToCreditorsAfterOneYearMapper;
+
+    @Mock
+    private ApiToTangibleAssetsNoteMapper apiToTangibleAssetsNoteMapper;
+
+    @Mock
+    private CalledUpSharedCapitalNotPaid calledUpSharedCapitalNotPaid;
+
+    @Mock
+    private OtherLiabilitiesOrAssets otherLiabilitiesOrAssets;
+
+    @Mock
+    private FixedAssets fixedAssets;
+
+    @Mock
+    private CurrentAssets currentAssets;
+
+    @Mock
+    private CapitalAndReserve capitalAndReserve;
+
+    @Mock
+    private BalanceSheetStatements balanceSheetStatements;
+
+    @Mock
+    private Company company;
+
+    @Mock
+    private Period period;
+
+    @Mock
+    private AccountingPolicies accountingPolicies;
+
+    @Mock
+    private StocksNote stocksNote;
+
+    @Mock
+    private Debtors debtors;
+
+    @Mock
+    private CreditorsWithinOneYear creditorsWithinOneYear;
+
+    @Mock
+    private CreditorsAfterOneYear creditorsAfterOneYear;
+
+    @Mock
+    private TangibleAssets tangibleAssets;
+
+    @Mock
+    private TangibleAssetsColumns column;
+
+    @InjectMocks
+    private SmallFullIXBRLMapper smallFullIXBRLMapper = new SmallFullIXBRLMapperImpl();
 
     @Test
-    @DisplayName("tests the mapping of the smallFull IXBRL model with a current and previous period")
-    void testSmallFullMapperCurrentAndPrevious() {
+    @DisplayName("Tests the mapping of the smallFull IXBRL model with optional resources")
+    void testMapperWithOptionalResources() {
 
         SmallFullApiData smallFullApiData = createSmallFullData(true);
 
-        SmallFullAccountIxbrl smallFullAccountIxbrl = SmallFullIXBRLMapper.INSTANCE.mapSmallFullIXBRLModel(smallFullApiData);
+        mockMandatoryFieldMappers(smallFullApiData);
+        mockOptionalFieldMappers(smallFullApiData);
+
+        SmallFullAccountIxbrl smallFullAccountIxbrl = smallFullIXBRLMapper.mapSmallFullIXBRLModel(smallFullApiData);
+
+        verifyMandatoryFieldMappersExecuted(smallFullApiData);
+        verifyOptionalFieldMappersExecuted(smallFullApiData);
 
         assertNotNull(smallFullAccountIxbrl);
-        assertApprovalsMapped(smallFullAccountIxbrl.getApprovalDate(), smallFullAccountIxbrl.getApprovalName());
-        assertBalanceSheetMapped(smallFullAccountIxbrl.getBalanceSheet(), true);
-        assertCompanyProfileMapped(smallFullAccountIxbrl.getCompany());
-        assertBalanceSheetNotesMapped(smallFullAccountIxbrl.getBalanceSheetNotes(), true );
+        assertIxbrlMandatoryDataMapped(smallFullAccountIxbrl);
+        assertIbxrlOptionalDataMapped(smallFullAccountIxbrl);
     }
 
     @Test
-    @DisplayName("tests the mapping of the smallFull IXBRL model with a current period Only")
-    void testSmallFullMapperCurrentOny() {
+    @DisplayName("Tests the mapping of the smallFull IXBRL model without optional resources")
+    void testMapperWithoutOptionalResources() {
 
         SmallFullApiData smallFullApiData = createSmallFullData(false);
 
-        SmallFullAccountIxbrl smallFullAccountIxbrl = SmallFullIXBRLMapper.INSTANCE.mapSmallFullIXBRLModel(smallFullApiData);
+        mockMandatoryFieldMappers(smallFullApiData);
+
+        SmallFullAccountIxbrl smallFullAccountIxbrl = smallFullIXBRLMapper.mapSmallFullIXBRLModel(smallFullApiData);
+
+        verifyMandatoryFieldMappersExecuted(smallFullApiData);
 
         assertNotNull(smallFullAccountIxbrl);
-        assertApprovalsMapped(smallFullAccountIxbrl.getApprovalDate(), smallFullAccountIxbrl.getApprovalName());
-        assertBalanceSheetMapped(smallFullAccountIxbrl.getBalanceSheet(), false);
-        assertCompanyProfileMapped(smallFullAccountIxbrl.getCompany());
-        assertBalanceSheetNotesMapped(smallFullAccountIxbrl.getBalanceSheetNotes(),false);
+        assertIxbrlMandatoryDataMapped(smallFullAccountIxbrl);
     }
 
-    private SmallFullApiData createSmallFullData(boolean isSameYearFiling) {
+    private void mockMandatoryFieldMappers(SmallFullApiData smallFullApiData) {
+
+        when(internalSmallFullIXBRLMapper.mapSmallFullIXBRLModel(smallFullApiData))
+                .thenReturn(createSmallFullAccountIxbrl());
+
+        when(apiToBalanceSheetMapper.apiToCalledUpSharedCapitalNotPaid(
+                smallFullApiData.getCurrentPeriod(), smallFullApiData.getPreviousPeriod()))
+                .thenReturn(calledUpSharedCapitalNotPaid);
+
+        when(apiToBalanceSheetMapper.apiToOtherLiabilitiesOrAssets(
+                smallFullApiData.getCurrentPeriod(), smallFullApiData.getPreviousPeriod()))
+                .thenReturn(otherLiabilitiesOrAssets);
+
+        when(apiToBalanceSheetMapper.apiToFixedAssets(
+                smallFullApiData.getCurrentPeriod(), smallFullApiData.getPreviousPeriod()))
+                .thenReturn(fixedAssets);
+
+        when(apiToBalanceSheetMapper.apiToCurrentAssets(
+                smallFullApiData.getCurrentPeriod(), smallFullApiData.getPreviousPeriod()))
+                .thenReturn(currentAssets);
+
+        when(apiToBalanceSheetMapper.apiToCapitalAndReserve(
+                smallFullApiData.getCurrentPeriod(), smallFullApiData.getPreviousPeriod()))
+                .thenReturn(capitalAndReserve);
+
+        when(apiToBalanceSheetMapper.apiToStatements(smallFullApiData.getBalanceSheetStatements()))
+                .thenReturn(balanceSheetStatements);
+
+        when(apiToCompanyMapper.apiToCompany(smallFullApiData.getCompanyProfile()))
+                .thenReturn(company);
+
+        when(apiToPeriodMapper.apiToPeriod(smallFullApiData.getCompanyProfile()))
+                .thenReturn(period);
+    }
+
+    private void verifyMandatoryFieldMappersExecuted(SmallFullApiData smallFullApiData) {
+
+        verify(internalSmallFullIXBRLMapper, times(1)).mapSmallFullIXBRLModel(smallFullApiData);
+
+        verify(apiToBalanceSheetMapper, times(1)).apiToCalledUpSharedCapitalNotPaid(
+                smallFullApiData.getCurrentPeriod(), smallFullApiData.getPreviousPeriod());
+
+        verify(apiToBalanceSheetMapper, times(1)).apiToOtherLiabilitiesOrAssets(
+                smallFullApiData.getCurrentPeriod(), smallFullApiData.getPreviousPeriod());
+
+        verify(apiToBalanceSheetMapper, times(1)).apiToFixedAssets(
+                smallFullApiData.getCurrentPeriod(), smallFullApiData.getPreviousPeriod());
+
+        verify(apiToBalanceSheetMapper, times(1)).apiToCurrentAssets(
+                smallFullApiData.getCurrentPeriod(), smallFullApiData.getPreviousPeriod());
+
+        verify(apiToBalanceSheetMapper, times(1)).apiToCapitalAndReserve(
+                smallFullApiData.getCurrentPeriod(), smallFullApiData.getPreviousPeriod());
+
+        verify(apiToBalanceSheetMapper, times(1))
+                .apiToStatements(smallFullApiData.getBalanceSheetStatements());
+
+        verify(apiToCompanyMapper, times(1))
+                .apiToCompany(smallFullApiData.getCompanyProfile());
+
+        verify(apiToPeriodMapper, times(1))
+                .apiToPeriod(smallFullApiData.getCompanyProfile());
+    }
+
+    private void assertIxbrlMandatoryDataMapped(SmallFullAccountIxbrl smallFullAccountIxbrl) {
+
+        assertEquals(NAME, smallFullAccountIxbrl.getApprovalName());
+
+        assertNotNull(smallFullAccountIxbrl.getBalanceSheet());
+        assertEquals(calledUpSharedCapitalNotPaid,
+                smallFullAccountIxbrl.getBalanceSheet().getCalledUpSharedCapitalNotPaid());
+        assertEquals(otherLiabilitiesOrAssets,
+                smallFullAccountIxbrl.getBalanceSheet().getOtherLiabilitiesOrAssets());
+        assertEquals(fixedAssets,
+                smallFullAccountIxbrl.getBalanceSheet().getFixedAssets());
+        assertEquals(currentAssets,
+                smallFullAccountIxbrl.getBalanceSheet().getCurrentAssets());
+        assertEquals(capitalAndReserve,
+                smallFullAccountIxbrl.getBalanceSheet().getCapitalAndReserve());
+        assertEquals(balanceSheetStatements,
+                smallFullAccountIxbrl.getBalanceSheet().getBalanceSheetStatements());
+
+        assertEquals(company, smallFullAccountIxbrl.getCompany());
+        assertEquals(period, smallFullAccountIxbrl.getPeriod());
+    }
+
+    private void mockOptionalFieldMappers(SmallFullApiData smallFullApiData) {
+
+        when(apiToAccountingPoliciesMapper.apiToAccountingPolicies(smallFullApiData.getAccountingPolicies()))
+                .thenReturn(accountingPolicies);
+
+        when(apiToStocksMapper.apiToStocks(
+                smallFullApiData.getStocks().getCurrentPeriod(),
+                smallFullApiData.getStocks().getPreviousPeriod()))
+                .thenReturn(stocksNote);
+
+        when(apiToDebtorsMapper.apiToDebtors(
+                smallFullApiData.getDebtors().getDebtorsCurrentPeriod(),
+                smallFullApiData.getDebtors().getDebtorsPreviousPeriod()))
+                .thenReturn(debtors);
+
+        when(apiToCreditorsWithinOneYearMapper.apiToCreditorsWithinOneYear(
+                smallFullApiData.getCreditorsWithinOneYear().getCreditorsWithinOneYearCurrentPeriod(),
+                smallFullApiData.getCreditorsWithinOneYear().getCreditorsWithinOneYearPreviousPeriod()))
+                .thenReturn(creditorsWithinOneYear);
+
+        when(apiToCreditorsAfterOneYearMapper.apiToCreditorsAfterOneYear(
+                smallFullApiData.getCreditorsAfterOneYear().getCurrentPeriod(),
+                smallFullApiData.getCreditorsAfterOneYear().getPreviousPeriod()))
+                .thenReturn(creditorsAfterOneYear);
+
+        when(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsNoteAdditionalInformation(
+                smallFullApiData.getTangibleAssets()))
+                .thenReturn(tangibleAssets);
+
+        when(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostAtPeriodStartMapper(
+                smallFullApiData.getTangibleAssets()))
+                .thenReturn(column);
+
+        when(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostAdditionsMapper(
+                smallFullApiData.getTangibleAssets()))
+                .thenReturn(column);
+
+        when(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostDisposalsMapper(
+                smallFullApiData.getTangibleAssets()))
+                .thenReturn(column);
+
+        when(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostRevaluationsMapper(
+                smallFullApiData.getTangibleAssets()))
+                .thenReturn(column);
+
+        when(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostTransfersMapper(
+                smallFullApiData.getTangibleAssets()))
+                .thenReturn(column);
+
+        when(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsCostAtPeriodEndMapper(
+                smallFullApiData.getTangibleAssets()))
+                .thenReturn(column);
+
+        when(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsDepreciationAtPeriodStartMapper(
+                smallFullApiData.getTangibleAssets()))
+                .thenReturn(column);
+
+        when(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsDepreciationChargeForYearMapper(
+                smallFullApiData.getTangibleAssets()))
+                .thenReturn(column);
+
+        when(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsDepreciationOnDisposalsMapper(
+                smallFullApiData.getTangibleAssets()))
+                .thenReturn(column);
+
+        when(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsDepreciationOtherAdjustmentsMapper(
+                smallFullApiData.getTangibleAssets()))
+                .thenReturn(column);
+
+        when(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsDepreciationAtPeriodEndMapper(
+                smallFullApiData.getTangibleAssets()))
+                .thenReturn(column);
+
+        when(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsNetBookValueCurrentPeriodMapper(
+                smallFullApiData.getTangibleAssets()))
+                .thenReturn(column);
+
+        when(apiToTangibleAssetsNoteMapper.apiToTangibleAssetsNetBookValuePreviousPeriodMapper(
+                smallFullApiData.getTangibleAssets()))
+                .thenReturn(column);
+    }
+
+    private void verifyOptionalFieldMappersExecuted(SmallFullApiData smallFullApiData) {
+
+        verify(apiToAccountingPoliciesMapper, times(1))
+                .apiToAccountingPolicies(smallFullApiData.getAccountingPolicies());
+
+        verify(apiToStocksMapper, times(1)).apiToStocks(
+                smallFullApiData.getStocks().getCurrentPeriod(),
+                smallFullApiData.getStocks().getPreviousPeriod());
+
+        verify(apiToDebtorsMapper, times(1)).apiToDebtors(
+                smallFullApiData.getDebtors().getDebtorsCurrentPeriod(),
+                smallFullApiData.getDebtors().getDebtorsPreviousPeriod());
+
+        verify(apiToCreditorsWithinOneYearMapper, times(1)).apiToCreditorsWithinOneYear(
+                smallFullApiData.getCreditorsWithinOneYear().getCreditorsWithinOneYearCurrentPeriod(),
+                smallFullApiData.getCreditorsWithinOneYear().getCreditorsWithinOneYearPreviousPeriod());
+
+        verify(apiToCreditorsAfterOneYearMapper, times(1)).apiToCreditorsAfterOneYear(
+                smallFullApiData.getCreditorsAfterOneYear().getCurrentPeriod(),
+                smallFullApiData.getCreditorsAfterOneYear().getPreviousPeriod());
+
+        verify(apiToTangibleAssetsNoteMapper, times(1)).apiToTangibleAssetsNoteAdditionalInformation(
+                smallFullApiData.getTangibleAssets());
+
+        verify(apiToTangibleAssetsNoteMapper, times(1)).apiToTangibleAssetsCostAtPeriodStartMapper(
+                smallFullApiData.getTangibleAssets());
+
+        verify(apiToTangibleAssetsNoteMapper, times(1)).apiToTangibleAssetsCostAdditionsMapper(
+                smallFullApiData.getTangibleAssets());
+
+        verify(apiToTangibleAssetsNoteMapper, times(1)).apiToTangibleAssetsCostDisposalsMapper(
+                smallFullApiData.getTangibleAssets());
+
+        verify(apiToTangibleAssetsNoteMapper, times(1)).apiToTangibleAssetsCostRevaluationsMapper(
+                smallFullApiData.getTangibleAssets());
+
+        verify(apiToTangibleAssetsNoteMapper, times(1)).apiToTangibleAssetsCostTransfersMapper(
+                smallFullApiData.getTangibleAssets());
+
+        verify(apiToTangibleAssetsNoteMapper, times(1)).apiToTangibleAssetsCostAtPeriodEndMapper(
+                smallFullApiData.getTangibleAssets());
+
+        verify(apiToTangibleAssetsNoteMapper, times(1)).apiToTangibleAssetsDepreciationAtPeriodStartMapper(
+                smallFullApiData.getTangibleAssets());
+
+        verify(apiToTangibleAssetsNoteMapper, times(1)).apiToTangibleAssetsDepreciationChargeForYearMapper(
+                smallFullApiData.getTangibleAssets());
+
+        verify(apiToTangibleAssetsNoteMapper, times(1)).apiToTangibleAssetsDepreciationOnDisposalsMapper(
+                smallFullApiData.getTangibleAssets());
+
+        verify(apiToTangibleAssetsNoteMapper, times(1)).apiToTangibleAssetsDepreciationOtherAdjustmentsMapper(
+                smallFullApiData.getTangibleAssets());
+
+        verify(apiToTangibleAssetsNoteMapper, times(1)).apiToTangibleAssetsDepreciationAtPeriodEndMapper(
+                smallFullApiData.getTangibleAssets());
+
+        verify(apiToTangibleAssetsNoteMapper, times(1)).apiToTangibleAssetsNetBookValueCurrentPeriodMapper(
+                smallFullApiData.getTangibleAssets());
+
+        verify(apiToTangibleAssetsNoteMapper, times(1)).apiToTangibleAssetsNetBookValuePreviousPeriodMapper(
+                smallFullApiData.getTangibleAssets());
+    }
+
+    private void assertIbxrlOptionalDataMapped(SmallFullAccountIxbrl smallFullAccountIxbrl) {
+
+        assertNotNull(smallFullAccountIxbrl.getAdditionalNotes());
+        assertEquals(accountingPolicies,
+                smallFullAccountIxbrl.getAdditionalNotes().getAccountingPolicies());
+
+        assertNotNull(smallFullAccountIxbrl.getBalanceSheetNotes());
+        assertEquals(stocksNote,
+                smallFullAccountIxbrl.getBalanceSheetNotes().getStocksNote());
+        assertEquals(debtors,
+                smallFullAccountIxbrl.getBalanceSheetNotes().getDebtorsNote());
+        assertEquals(creditorsWithinOneYear,
+                smallFullAccountIxbrl.getBalanceSheetNotes().getCreditorsWithinOneYearNote());
+        assertEquals(creditorsAfterOneYear,
+                smallFullAccountIxbrl.getBalanceSheetNotes().getCreditorsAfterOneYearNote());
+        assertEquals(tangibleAssets,
+                smallFullAccountIxbrl.getBalanceSheetNotes().getTangibleAssets());
+    }
+
+    private SmallFullAccountIxbrl createSmallFullAccountIxbrl() {
+
+        SmallFullAccountIxbrl smallFullAccountIxbrl = new SmallFullAccountIxbrl();
+        smallFullAccountIxbrl.setApprovalName(NAME);
+        return smallFullAccountIxbrl;
+    }
+
+    private SmallFullApiData createSmallFullData(boolean hasOptionalResources) {
 
         SmallFullApiData smallFullApiData = new SmallFullApiData();
 
         smallFullApiData.setApproval(createApproval());
-        smallFullApiData.setCompanyProfile(createCompanyProfile(isSameYearFiling));
+        smallFullApiData.setCompanyProfile(createCompanyProfile());
         smallFullApiData.setCurrentPeriod(createCurrentPeriod());
-        if(isSameYearFiling == true) {
-            smallFullApiData.setPreviousPeriod(createPreviousPeriod());
-        }
+        smallFullApiData.setPreviousPeriod(createPreviousPeriod());
+        smallFullApiData.setBalanceSheetStatements(createBalanceSheetStatements());
 
-        smallFullApiData.setStocks(createStocks());
-        smallFullApiData.setDebtors(createDebtors());
-        smallFullApiData.setCreditorsWithinOneYear(createCreditorsWithinOneYear());
-        smallFullApiData.setCreditorsAfterOneYear(createCreditorsAfterOneYear());
+        if (hasOptionalResources) {
+            smallFullApiData.setAccountingPolicies(createAccountingPolicies());
+            smallFullApiData.setStocks(createStocks());
+            smallFullApiData.setDebtors(createDebtors());
+            smallFullApiData.setCreditorsWithinOneYear(createCreditorsWithinOneYear());
+            smallFullApiData.setCreditorsAfterOneYear(createCreditorsAfterOneYear());
+            smallFullApiData.setTangibleAssets(createTangible());
+        }
 
         return smallFullApiData;
     }
 
     private CurrentPeriodApi createCurrentPeriod() {
 
-        CurrentPeriodApi currentPeriod = new CurrentPeriodApi();
-        currentPeriod.setBalanceSheet(createBalanceSheetValues());
+        CurrentPeriodApi currentPeriodApi = new CurrentPeriodApi();
+        currentPeriodApi.setBalanceSheet(createBalanceSheet());
 
-        return currentPeriod;
+        return currentPeriodApi;
     }
 
     private PreviousPeriodApi  createPreviousPeriod() {
 
-        PreviousPeriodApi previousPeriod = new PreviousPeriodApi();
-        previousPeriod.setBalanceSheet(createBalanceSheetValues());
+        PreviousPeriodApi previousPeriodApi = new PreviousPeriodApi();
+        previousPeriodApi.setBalanceSheet(createBalanceSheet());
 
-        return previousPeriod;
+        return previousPeriodApi;
+    }
+
+    private BalanceSheetApi createBalanceSheet() {
+
+        BalanceSheetApi balanceSheetApi = new BalanceSheetApi();
+        balanceSheetApi.setCalledUpShareCapitalNotPaid(1L);
+        balanceSheetApi.setOtherLiabilitiesOrAssets(new OtherLiabilitiesOrAssetsApi());
+        balanceSheetApi.setFixedAssets(new FixedAssetsApi());
+        balanceSheetApi.setCurrentAssets(new CurrentAssetsApi());
+        balanceSheetApi.setCapitalAndReserves(new CapitalAndReservesApi());
+
+        return balanceSheetApi;
+    }
+
+    private BalanceSheetStatementsApi createBalanceSheetStatements() {
+
+        return new BalanceSheetStatementsApi();
     }
 
     private ApprovalApi createApproval() {
 
-        ApprovalApi approval = new ApprovalApi();
-        approval.setDate(LocalDate.of(2018, 12, 31));
-        approval.setName(NAME);
+        ApprovalApi approvalApi = new ApprovalApi();
+        approvalApi.setDate(LocalDate.of(2018, 1, 1));
 
-        return approval;
+        return approvalApi;
     }
 
-    private CompanyProfileApi createCompanyProfile(boolean isMultiYearFiling) {
+    private CompanyProfileApi createCompanyProfile() {
 
-        CompanyProfileApi companyProfile = new CompanyProfileApi();
-        companyProfile.setCompanyName(COMPANY_NAME);
-        companyProfile.setCompanyNumber(COMPANY_NUMBER);
-        companyProfile.setJurisdiction(JURISDICTION);
-        createAccountsFilingDates(isMultiYearFiling, companyProfile);
-
-        return companyProfile;
+        return new CompanyProfileApi();
     }
 
-    private CompanyProfileApi createAccountsFilingDates(boolean isMultiYearFiling, CompanyProfileApi companyProfileApi ) {
+    private AccountingPoliciesApi createAccountingPolicies() {
 
-        CompanyAccountApi companyAccountsApi = new CompanyAccountApi();
-        LastAccountsApi lastAccountsApi = new LastAccountsApi();
-        NextAccountsApi nextAccountsApi = new NextAccountsApi();
-
-        if (isMultiYearFiling == true) {
-            lastAccountsApi.setPeriodEndOn(LocalDate.of(2017,12,31));
-            lastAccountsApi.setPeriodStartOn(LocalDate.of(2017, 01, 01));
-        }
-
-        nextAccountsApi.setPeriodEndOn(LocalDate.of(2018,12,31));
-        nextAccountsApi.setPeriodStartOn(LocalDate.of(2018,01,01));
-
-        companyAccountsApi.setLastAccounts(lastAccountsApi);
-        companyAccountsApi.setNextAccounts(nextAccountsApi);
-        companyProfileApi.setAccounts(companyAccountsApi);
-
-        return companyProfileApi;
-    }
-
-    private BalanceSheetApi createBalanceSheetValues() {
-
-        BalanceSheetApi balanceSheet = new BalanceSheetApi();
-        balanceSheet.setCapitalAndReserves(createCapitalAndReserve());
-        balanceSheet.setCurrentAssets(createCurrentAssets());
-        balanceSheet.setFixedAssets(createFixedAssets());
-        balanceSheet.setOtherLiabilitiesOrAssets(createOtherLiabilitiesOrAssets());
-        balanceSheet.setCalledUpShareCapitalNotPaid(VALUE_ONE);
-
-        return balanceSheet;
-    }
-
-    private OtherLiabilitiesOrAssetsApi createOtherLiabilitiesOrAssets() {
-
-        OtherLiabilitiesOrAssetsApi otherLiabilitiesOrAssets = new OtherLiabilitiesOrAssetsApi();
-        otherLiabilitiesOrAssets.setTotalNetAssets(new Long(VALUE_ONE));
-        otherLiabilitiesOrAssets.setAccrualsAndDeferredIncome(new Long(VALUE_TWO));
-        otherLiabilitiesOrAssets.setCreditorsAfterOneYear(new Long(VALUE_THREE));
-        otherLiabilitiesOrAssets.setCreditorsDueWithinOneYear(new Long(VALUE_ONE));
-        otherLiabilitiesOrAssets.setNetCurrentAssets(new Long(VALUE_TWO));
-        otherLiabilitiesOrAssets.setPrepaymentsAndAccruedIncome(new Long(VALUE_THREE));
-        otherLiabilitiesOrAssets.setTotalAssetsLessCurrentLiabilities(new Long(VALUE_ONE));
-        otherLiabilitiesOrAssets.setProvisionForLiabilities(new Long(VALUE_TWO));
-
-        return otherLiabilitiesOrAssets;
-    }
-
-    private FixedAssetsApi createFixedAssets() {
-
-        FixedAssetsApi fixedAssets = new FixedAssetsApi();
-        fixedAssets.setTangible(new Long(VALUE_ONE));
-        fixedAssets.setTotal(new Long(VALUE_TWO));
-
-        return fixedAssets;
-    }
-
-    private CurrentAssetsApi createCurrentAssets() {
-
-        CurrentAssetsApi currentAssets = new CurrentAssetsApi();
-        currentAssets.setCashInBankAndInHand(new Long(VALUE_ONE));
-        currentAssets.setDebtors(new Long(VALUE_TWO));
-        currentAssets.setStocks(new Long(VALUE_THREE));
-        currentAssets.setTotal(new Long(VALUE_ONE));
-
-        return currentAssets;
-    }
-
-    private CapitalAndReservesApi createCapitalAndReserve() {
-
-        CapitalAndReservesApi capitalAndReserves = new CapitalAndReservesApi();
-        capitalAndReserves.setCalledUpShareCapital(new Long(VALUE_ONE));
-        capitalAndReserves.setOtherReserves(new Long(VALUE_TWO));
-        capitalAndReserves.setProfitAndLoss(new Long(VALUE_THREE));
-        capitalAndReserves.setSharePremiumAccount(new Long(VALUE_ONE));
-        capitalAndReserves.setTotalShareholdersFunds(new Long(VALUE_TWO));
-
-        return capitalAndReserves;
-    }
-
-
-    private void assertBalanceSheetMapped(BalanceSheet balanceSheet, boolean isMultiYearFiling) {
-
-        assertCapitalAndReserve(balanceSheet.getCapitalAndReserve(), isMultiYearFiling);
-        assertCurrentAssets(balanceSheet.getCurrentAssets(), isMultiYearFiling);
-        assertFixedAssets(balanceSheet.getFixedAssets(), isMultiYearFiling);
-        assertOtherLiabilitiesOrAssets(balanceSheet.getOtherLiabilitiesOrAssets(), isMultiYearFiling);
-        assertCalledUpSharedCapitalNotPaid(balanceSheet.getCalledUpSharedCapitalNotPaid(), isMultiYearFiling);
-    }
-
-    private void assertCalledUpSharedCapitalNotPaid(CalledUpSharedCapitalNotPaid calledUpSharedCapitalNotPaid, boolean isMultiYearFiling) {
-
-        assertNotNull(calledUpSharedCapitalNotPaid);
-        assertEquals(new Long(VALUE_ONE), calledUpSharedCapitalNotPaid.getCurrentAmount());
-
-        if (isMultiYearFiling == true) {
-            assertEquals(new Long(VALUE_ONE), calledUpSharedCapitalNotPaid.getPreviousAmount());
-        }
-    }
-
-    private void assertOtherLiabilitiesOrAssets(OtherLiabilitiesOrAssets otherLiabilitiesOrAssets, boolean isMultiYearFiling) {
-
-        assertNotNull(otherLiabilitiesOrAssets);
-        assertEquals(new Long(VALUE_ONE), otherLiabilitiesOrAssets.getCurrentTotalNetAssets());
-        assertEquals(new Long(VALUE_TWO), otherLiabilitiesOrAssets.getAccrualsAndDeferredIncome().getCurrentAmount());
-        assertEquals(new Long(VALUE_THREE), otherLiabilitiesOrAssets.getCreditorsAmountsFallingDueAfterMoreThanOneYear().getCurrentAmount());
-        assertEquals(new Long(VALUE_ONE), otherLiabilitiesOrAssets.getCreditorsAmountsFallingDueWithinOneYear().getCurrentAmount());
-        assertEquals(new Long(VALUE_TWO), otherLiabilitiesOrAssets.getNetCurrentAssets().getCurrentAmount());
-        assertEquals(new Long(VALUE_THREE), otherLiabilitiesOrAssets.getPrepaymentsAndAccruedIncome().getCurrentAmount());
-        assertEquals(new Long(VALUE_ONE), otherLiabilitiesOrAssets.getTotalAssetsLessCurrentLiabilities().getCurrentAmount());
-        assertEquals(new Long(VALUE_TWO), otherLiabilitiesOrAssets.getProvisionForLiabilities().getCurrentAmount());
-
-        if (isMultiYearFiling == true) {
-
-            assertEquals(new Long(VALUE_ONE), otherLiabilitiesOrAssets.getPreviousTotalNetAssets());
-            assertEquals(new Long(VALUE_TWO), otherLiabilitiesOrAssets.getAccrualsAndDeferredIncome().getPreviousAmount());
-            assertEquals(new Long(VALUE_THREE), otherLiabilitiesOrAssets.getCreditorsAmountsFallingDueAfterMoreThanOneYear().getPreviousAmount());
-            assertEquals(new Long(VALUE_ONE), otherLiabilitiesOrAssets.getCreditorsAmountsFallingDueWithinOneYear().getPreviousAmount());
-            assertEquals(new Long(VALUE_TWO), otherLiabilitiesOrAssets.getNetCurrentAssets().getPreviousAmount());
-            assertEquals(new Long(VALUE_THREE),otherLiabilitiesOrAssets.getPrepaymentsAndAccruedIncome().getPreviousAmount());
-            assertEquals(new Long(VALUE_ONE), otherLiabilitiesOrAssets.getTotalAssetsLessCurrentLiabilities().getPreviousAmount());
-            assertEquals(new Long(VALUE_TWO), otherLiabilitiesOrAssets.getProvisionForLiabilities().getPreviousAmount());
-        }
-    }
-
-    private void assertFixedAssets(FixedAssets fixedAssets, boolean isMultiYearFiling) {
-
-        assertNotNull(fixedAssets);
-        assertEquals(new Long(VALUE_ONE), fixedAssets.getTangibleAssets().getCurrentAmount());
-        assertEquals(new Long(VALUE_TWO), fixedAssets.getTotalFixedAssetsCurrent());
-
-        if (isMultiYearFiling == true) {
-
-            assertEquals(new Long(VALUE_ONE), fixedAssets.getTangibleAssets().getPreviousAmount());
-            assertEquals(new Long(VALUE_TWO), fixedAssets.getTotalFixedAssetsPrevious());
-        }
-    }
-
-    private void assertCurrentAssets(CurrentAssets currentAssets, boolean isMultiYearFiling) {
-
-        assertNotNull(currentAssets);
-        assertEquals(new Long(VALUE_ONE), currentAssets.getCashAtBankAndInHand().getCurrentAmount());
-        assertEquals(new Long(VALUE_TWO), currentAssets.getDebtors().getCurrentAmount());
-        assertEquals(new Long(VALUE_THREE), currentAssets.getStocks().getCurrentAmount());
-        assertEquals(new Long(VALUE_ONE), currentAssets.getCurrentTotal());
-
-        if (isMultiYearFiling == true) {
-
-            assertEquals(new Long(VALUE_ONE), currentAssets.getCashAtBankAndInHand().getPreviousAmount());
-            assertEquals(new Long(VALUE_TWO), currentAssets.getDebtors().getPreviousAmount());
-            assertEquals(new Long(VALUE_THREE), currentAssets.getStocks().getPreviousAmount());
-            assertEquals(new Long(VALUE_ONE), currentAssets.getPreviousTotal());
-        }
-    }
-
-    private void assertCapitalAndReserve(CapitalAndReserve capitalAndReserve, boolean isMultiYearFiling) {
-
-        assertNotNull(capitalAndReserve);
-        assertEquals(new Long(VALUE_ONE), capitalAndReserve.getCalledUpShareCapital().getCurrentAmount());
-        assertEquals(new Long(VALUE_TWO), capitalAndReserve.getOtherReserves().getCurrentAmount());
-        assertEquals(new Long(VALUE_THREE), capitalAndReserve.getProfitAndLoss().getCurrentAmount());
-        assertEquals(new Long(VALUE_ONE), capitalAndReserve.getSharePremiumAccount().getCurrentAmount());
-        assertEquals(new Long(VALUE_TWO), capitalAndReserve.getTotalShareHoldersFunds().getCurrentAmount());
-
-        if (isMultiYearFiling == true) {
-
-            assertEquals(new Long(VALUE_ONE),capitalAndReserve.getCalledUpShareCapital().getPreviousAmount());
-            assertEquals(new Long(VALUE_TWO), capitalAndReserve.getOtherReserves().getPreviousAmount());
-            assertEquals(new Long(VALUE_THREE), capitalAndReserve.getProfitAndLoss().getPreviousAmount());
-            assertEquals(new Long(VALUE_ONE), capitalAndReserve.getSharePremiumAccount().getPreviousAmount());
-            assertEquals(new Long(VALUE_TWO), capitalAndReserve.getTotalShareHoldersFunds().getPreviousAmount());
-        }
-    }
-
-    private void assertCompanyProfileMapped(Company company) {
-
-        assertNotNull(company);
-        assertEquals(COMPANY_NAME, company.getCompanyName());
-        assertEquals(COMPANY_NUMBER, company.getCompanyNumber());
-        assertEquals(JURISDICTION, company.getJurisdiction());
-    }
-
-    private void assertApprovalsMapped(String approvalDate, String approvalName) {
-
-        assertEquals("31 December 2018", approvalDate);
-        assertEquals(NAME, approvalName);
-    }
-
-    private void assertBalanceSheetNotesMapped(BalanceSheetNotes balanceSheetNotes, boolean isMultiYearFiling) {
-        assertStocksNoteMapped(balanceSheetNotes.getStocksNote(), isMultiYearFiling);
-        assertDebtorsNoteMapped(balanceSheetNotes.getDebtorsNote(), isMultiYearFiling);
-        assertCreditorsWithinOneYearNoteMapped(balanceSheetNotes.getCreditorsWithinOneYearNote(), isMultiYearFiling);
-        assertCreditorsAfterOneYearNoteMapped(balanceSheetNotes.getCreditorsAfterOneYearNote(), isMultiYearFiling);
-    }
-
-    private void assertDebtorsNoteMapped(Debtors debtorsNote, boolean isMultiYearFiling) {
-        assertEquals(DETAILS, debtorsNote.getDetails());
-        assertEquals(VALUE_ONE, debtorsNote.getGreaterThanOneYear().getCurrentAmount());
-        assertEquals(VALUE_TWO, debtorsNote.getOtherDebtors().getCurrentAmount());
-        assertEquals(VALUE_THREE, debtorsNote.getPrepaymentsAndAccruedIncome().getCurrentAmount());
-        assertEquals(VALUE_ONE, debtorsNote.getTradeDebtors().getCurrentAmount());
-        assertEquals(VALUE_TWO, debtorsNote.getTotal().getCurrentAmount());
-
-        if (isMultiYearFiling == true) {
-
-            assertEquals(VALUE_ONE, debtorsNote.getGreaterThanOneYear().getPreviousAmount());
-            assertEquals(VALUE_TWO, debtorsNote.getOtherDebtors().getPreviousAmount());
-            assertEquals(VALUE_THREE, debtorsNote.getPrepaymentsAndAccruedIncome().getPreviousAmount());
-            assertEquals(VALUE_ONE, debtorsNote.getTradeDebtors().getPreviousAmount());
-            assertEquals(VALUE_TWO, debtorsNote.getTotal().getPreviousAmount());
-        }
-    }
-    
-    private void assertStocksNoteMapped(StocksNote stocksNote, boolean isMultiYearFiling) {
-        assertEquals(VALUE_ONE, stocksNote.getStocks().getCurrentAmount());
-        assertEquals(VALUE_TWO, stocksNote.getPaymentsOnAccount().getCurrentAmount());
-        assertEquals(VALUE_THREE, stocksNote.getTotal().getCurrentAmount());
-
-        if (isMultiYearFiling == true) {
-
-            assertEquals(VALUE_ONE, stocksNote.getStocks().getPreviousAmount());
-            assertEquals(VALUE_TWO, stocksNote.getPaymentsOnAccount().getPreviousAmount());
-            assertEquals(VALUE_THREE, stocksNote.getTotal().getPreviousAmount());
-        }
-    }
-    
-    private void assertCreditorsWithinOneYearNoteMapped(CreditorsWithinOneYear creditorsWithinOneYearNote, boolean isMultiYearFiling) {
-        assertEquals(DETAILS, creditorsWithinOneYearNote.getDetails());
-        assertEquals(VALUE_ONE, creditorsWithinOneYearNote.getAccrualsAndDeferredIncome().getCurrentAmount());
-        assertEquals(VALUE_TWO, creditorsWithinOneYearNote.getBankLoansAndOverdrafts().getCurrentAmount());
-        assertEquals(VALUE_THREE, creditorsWithinOneYearNote.getFinanceLeasesAndHirePurchaseContracts().getCurrentAmount());
-        assertEquals(VALUE_ONE, creditorsWithinOneYearNote.getOtherCreditors().getCurrentAmount());
-        assertEquals(VALUE_TWO, creditorsWithinOneYearNote.getTaxationAndSocialSecurity().getCurrentAmount());
-        assertEquals(VALUE_THREE, creditorsWithinOneYearNote.getTradeCreditors().getCurrentAmount());
-        assertEquals(VALUE_ONE, creditorsWithinOneYearNote.getTotal().getCurrentAmount());
-
-        if (isMultiYearFiling == true) {
-
-            assertEquals(VALUE_ONE, creditorsWithinOneYearNote.getAccrualsAndDeferredIncome().getPreviousAmount());
-            assertEquals(VALUE_TWO, creditorsWithinOneYearNote.getBankLoansAndOverdrafts().getPreviousAmount());
-            assertEquals(VALUE_THREE, creditorsWithinOneYearNote.getFinanceLeasesAndHirePurchaseContracts().getPreviousAmount());
-            assertEquals(VALUE_ONE, creditorsWithinOneYearNote.getOtherCreditors().getPreviousAmount());
-            assertEquals(VALUE_TWO, creditorsWithinOneYearNote.getTaxationAndSocialSecurity().getPreviousAmount());
-            assertEquals(VALUE_THREE, creditorsWithinOneYearNote.getTradeCreditors().getPreviousAmount());
-            assertEquals(VALUE_ONE, creditorsWithinOneYearNote.getTotal().getPreviousAmount());
-        }
-    }
-
-    private void assertCreditorsAfterOneYearNoteMapped(CreditorsAfterOneYear creditorsAfterOneYearNote, boolean isMultiYearFiling) {
-        assertEquals(DETAILS, creditorsAfterOneYearNote.getDetails());
-        assertEquals(VALUE_ONE, creditorsAfterOneYearNote.getBankLoansAndOverdrafts().getCurrentAmount());
-        assertEquals(VALUE_TWO, creditorsAfterOneYearNote.getFinanceLeasesAndHirePurchaseContracts().getCurrentAmount());
-        assertEquals(VALUE_THREE, creditorsAfterOneYearNote.getOtherCreditors().getCurrentAmount());
-        assertEquals(VALUE_ONE, creditorsAfterOneYearNote.getTotal().getCurrentAmount());
-
-        if (isMultiYearFiling == true) {
-
-            assertEquals(VALUE_ONE, creditorsAfterOneYearNote.getBankLoansAndOverdrafts().getPreviousAmount());
-            assertEquals(VALUE_TWO, creditorsAfterOneYearNote.getFinanceLeasesAndHirePurchaseContracts().getPreviousAmount());
-            assertEquals(VALUE_THREE, creditorsAfterOneYearNote.getOtherCreditors().getPreviousAmount());
-            assertEquals(VALUE_ONE, creditorsAfterOneYearNote.getTotal().getPreviousAmount());
-        }
+        return new AccountingPoliciesApi();
     }
     
     private DebtorsApi createDebtors() {
 
-        DebtorsApi debtors = new DebtorsApi();
+        DebtorsApi debtorsApi = new DebtorsApi();
+        debtorsApi.setDebtorsCurrentPeriod(new CurrentPeriod());
+        debtorsApi.setDebtorsPreviousPeriod(new PreviousPeriod());
 
-        CurrentPeriod debtorsCurrentPeriod = new CurrentPeriod();
-        debtorsCurrentPeriod.setDetails(DETAILS);
-        debtorsCurrentPeriod.setGreaterThanOneYear(VALUE_ONE);
-        debtorsCurrentPeriod.setOtherDebtors(VALUE_TWO);
-        debtorsCurrentPeriod.setPrepaymentsAndAccruedIncome(VALUE_THREE);
-        debtorsCurrentPeriod.setTradeDebtors(VALUE_ONE);
-        debtorsCurrentPeriod.setTotal(VALUE_TWO);
-        debtors.setDebtorsCurrentPeriod(debtorsCurrentPeriod);
-
-        PreviousPeriod debtorsPreviousPeriod = new PreviousPeriod();
-        debtorsPreviousPeriod.setGreaterThanOneYear(VALUE_ONE);
-        debtorsPreviousPeriod.setOtherDebtors(VALUE_TWO);
-        debtorsPreviousPeriod.setPrepaymentsAndAccruedIncome(VALUE_THREE);
-        debtorsPreviousPeriod.setTradeDebtors(VALUE_ONE);
-        debtorsPreviousPeriod.setTotal(VALUE_TWO);
-        debtors.setDebtorsPreviousPeriod(debtorsPreviousPeriod);
-
-        return debtors;
+        return debtorsApi;
     }
     
     private StocksApi createStocks() {
 
-        StocksApi stocks = new StocksApi();
+        StocksApi stocksApi = new StocksApi();
+        stocksApi.setCurrentPeriod(
+                new uk.gov.companieshouse.api.model.accounts.smallfull.stocks.CurrentPeriod());
+        stocksApi.setPreviousPeriod(
+                new uk.gov.companieshouse.api.model.accounts.smallfull.stocks.PreviousPeriod());
 
-        uk.gov.companieshouse.api.model.accounts.smallfull.stocks.CurrentPeriod stocksCurrentPeriod = 
-                new uk.gov.companieshouse.api.model.accounts.smallfull.stocks.CurrentPeriod();
-        
-        stocksCurrentPeriod.setStocks(VALUE_ONE);
-        stocksCurrentPeriod.setPaymentsOnAccount(VALUE_TWO);
-        stocksCurrentPeriod.setTotal(VALUE_THREE);
-        stocks.setCurrentPeriod(stocksCurrentPeriod);
-
-        uk.gov.companieshouse.api.model.accounts.smallfull.stocks.PreviousPeriod stocksPreviousPeriod
-        = new uk.gov.companieshouse.api.model.accounts.smallfull.stocks.PreviousPeriod();
-        
-        stocksPreviousPeriod.setStocks(VALUE_ONE);
-        stocksPreviousPeriod.setPaymentsOnAccount(VALUE_TWO);
-        stocksPreviousPeriod.setTotal(VALUE_THREE);
-        stocks.setPreviousPeriod(stocksPreviousPeriod);
-
-        return stocks;
+        return stocksApi;
     }    
     
     private CreditorsWithinOneYearApi createCreditorsWithinOneYear() {
 
       CreditorsWithinOneYearApi creditorsWithinOneYearApi = new CreditorsWithinOneYearApi();
-
-      uk.gov.companieshouse.api.model.accounts.smallfull.creditorswithinoneyear.CurrentPeriod creditorsWithinOneYearCurrentPeriod =
-          new uk.gov.companieshouse.api.model.accounts.smallfull.creditorswithinoneyear.CurrentPeriod();
-      
-      creditorsWithinOneYearCurrentPeriod.setDetails(DETAILS);
-      creditorsWithinOneYearCurrentPeriod.setAccrualsAndDeferredIncome(VALUE_ONE);
-      creditorsWithinOneYearCurrentPeriod.setBankLoansAndOverdrafts(VALUE_TWO);
-      creditorsWithinOneYearCurrentPeriod.setFinanceLeasesAndHirePurchaseContracts(VALUE_THREE);
-      creditorsWithinOneYearCurrentPeriod.setOtherCreditors(VALUE_ONE);
-      creditorsWithinOneYearCurrentPeriod.setTaxationAndSocialSecurity(VALUE_TWO);
-      creditorsWithinOneYearCurrentPeriod.setTradeCreditors(VALUE_THREE);
-      creditorsWithinOneYearCurrentPeriod.setTotal(VALUE_ONE);
-      creditorsWithinOneYearApi.setCreditorsWithinOneYearCurrentPeriod(creditorsWithinOneYearCurrentPeriod);
-
-      uk.gov.companieshouse.api.model.accounts.smallfull.creditorswithinoneyear.PreviousPeriod creditorsWithinOneYearPreviousPeriod =
-          new uk.gov.companieshouse.api.model.accounts.smallfull.creditorswithinoneyear.PreviousPeriod();
-      
-      creditorsWithinOneYearPreviousPeriod.setAccrualsAndDeferredIncome(VALUE_ONE);
-      creditorsWithinOneYearPreviousPeriod.setBankLoansAndOverdrafts(VALUE_TWO);
-      creditorsWithinOneYearPreviousPeriod.setFinanceLeasesAndHirePurchaseContracts(VALUE_THREE);
-      creditorsWithinOneYearPreviousPeriod.setOtherCreditors(VALUE_ONE);
-      creditorsWithinOneYearPreviousPeriod.setTaxationAndSocialSecurity(VALUE_TWO);
-      creditorsWithinOneYearPreviousPeriod.setTradeCreditors(VALUE_THREE);
-      creditorsWithinOneYearPreviousPeriod.setTotal(VALUE_ONE);
-      creditorsWithinOneYearApi.setCreditorsWithinOneYearPreviousPeriod(creditorsWithinOneYearPreviousPeriod);
+      creditorsWithinOneYearApi.setCreditorsWithinOneYearCurrentPeriod(
+              new uk.gov.companieshouse.api.model.accounts.smallfull.creditorswithinoneyear.CurrentPeriod());
+      creditorsWithinOneYearApi.setCreditorsWithinOneYearPreviousPeriod(
+              new uk.gov.companieshouse.api.model.accounts.smallfull.creditorswithinoneyear.PreviousPeriod());
 
       return creditorsWithinOneYearApi;
   }
@@ -485,29 +533,16 @@ public class SmallFullIXBRLMapperTest {
     private CreditorsAfterOneYearApi createCreditorsAfterOneYear() {
 
         CreditorsAfterOneYearApi creditorsAfterOneYearApi = new CreditorsAfterOneYearApi();
-
-        uk.gov.companieshouse.api.model.accounts.smallfull.creditorsafteroneyear.CurrentPeriod creditorsAfterOneYearCurrentPeriod =
-            new uk.gov.companieshouse.api.model.accounts.smallfull.creditorsafteroneyear.CurrentPeriod();
-        
-        creditorsAfterOneYearCurrentPeriod.setDetails(DETAILS);
-        creditorsAfterOneYearCurrentPeriod.setBankLoansAndOverdrafts(VALUE_ONE);
-        creditorsAfterOneYearCurrentPeriod.setFinanceLeasesAndHirePurchaseContracts(VALUE_TWO);
-        creditorsAfterOneYearCurrentPeriod.setOtherCreditors(VALUE_THREE);
-        creditorsAfterOneYearCurrentPeriod.setTotal(VALUE_ONE);
-        
-        creditorsAfterOneYearApi.setCurrentPeriod(creditorsAfterOneYearCurrentPeriod);
-
-
-        uk.gov.companieshouse.api.model.accounts.smallfull.creditorsafteroneyear.PreviousPeriod creditorsAfterOneYearPreviousPeriod =
-            new uk.gov.companieshouse.api.model.accounts.smallfull.creditorsafteroneyear.PreviousPeriod();
-        
-        creditorsAfterOneYearPreviousPeriod.setBankLoansAndOverdrafts(VALUE_ONE);
-        creditorsAfterOneYearPreviousPeriod.setFinanceLeasesAndHirePurchaseContracts(VALUE_TWO);
-        creditorsAfterOneYearPreviousPeriod.setOtherCreditors(VALUE_THREE);
-        creditorsAfterOneYearPreviousPeriod.setTotal(VALUE_ONE);
-        
-        creditorsAfterOneYearApi.setPreviousPeriod(creditorsAfterOneYearPreviousPeriod);
+        creditorsAfterOneYearApi.setCurrentPeriod(
+                new uk.gov.companieshouse.api.model.accounts.smallfull.creditorsafteroneyear.CurrentPeriod());
+        creditorsAfterOneYearApi.setPreviousPeriod(
+                new uk.gov.companieshouse.api.model.accounts.smallfull.creditorsafteroneyear.PreviousPeriod());
 
         return creditorsAfterOneYearApi;
-    }    
-}*/
+    }
+
+    private TangibleApi createTangible() {
+
+        return new TangibleApi();
+    }
+}


### PR DESCRIPTION
Before this change, concurrent requests would exhibit unexpected behaviour, resulting in missing / mixed up data present in the resulting iXBRL. This change alters the scope of each mapper from the default Singleton to instead be request scoped.

Fixes SFA-1270