### PR TITLE
Tidy up by removing unused parameter

### DIFF
--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/document/description/RetrieveApiEnumerationDescription.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/document/description/RetrieveApiEnumerationDescription.java
@@ -17,5 +17,5 @@ public interface RetrieveApiEnumerationDescription {
      * @throws IOException
      */
     String getApiEnumerationDescription(String fileName, String identifier, String accountType,
-                                        Map<String, String> descriptionValues, Map<String, String> requestParameters) throws IOException;
+                                        Map<String, String> requestParameters) throws IOException;
 }

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/document/description/impl/RetrieveApiEnumerationDescriptionImpl.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/document/description/impl/RetrieveApiEnumerationDescriptionImpl.java
@@ -30,7 +30,7 @@ public class RetrieveApiEnumerationDescriptionImpl implements RetrieveApiEnumera
      */
     @Override
     public String getApiEnumerationDescription(String fileName, String identifier, String accountType,
-                                               Map<String, String> parameters, Map<String, String> requestParameters)
+                                               Map<String, String> requestParameters)
             throws IOException {
 
 

--- a/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
+++ b/document-generator-api/src/main/java/uk/gov/companieshouse/document/generator/api/service/impl/DocumentGeneratorServiceImpl.java
@@ -290,7 +290,7 @@ public class DocumentGeneratorServiceImpl implements DocumentGeneratorService {
         try {
             description = retrieveApiEnumerationDescription.getApiEnumerationDescription(
                     FILING_DESCRIPTIONS_FILE_NAME, DESCRIPTION_IDENTIFIERS_KEY,
-                    documentInfoResponse.getDescriptionIdentifier(), documentInfoResponse.getDescriptionValues(), requestParameters);
+                    documentInfoResponse.getDescriptionIdentifier(), requestParameters);
         } catch (IOException ioe) {
             createAndLogErrorMessage("Error retrieving description from api-enumeration from: "
                     + FILING_DESCRIPTIONS_FILE_NAME, ioe, requestParameters);

--- a/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/document/RetrieveApiEnumerationDescriptionTest.java
+++ b/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/document/RetrieveApiEnumerationDescriptionTest.java
@@ -22,7 +22,7 @@ public class RetrieveApiEnumerationDescriptionTest {
 
     private static final String DESCRIPTION_IDENTIFIERS_KEY_INVALID = "desc";
 
-    private static final String POPULATED_RESPONSE = "Abridged accounts made up to {period_end_on}";
+    private static final String RESPONSE_WITH_PLACEHOLDER = "Abridged accounts made up to {period_end_on}";
 
     private static final String EMPTY_RESPONSE = "";
 
@@ -54,10 +54,9 @@ public class RetrieveApiEnumerationDescriptionTest {
     public void testValidReturnValue() throws IOException {
 
         String result = retrieveApiEnumerationDescription.getApiEnumerationDescription(FILING_DESCRIPTIONS_FILE_NAME_VALID,
-                DESCRIPTION_IDENTIFIERS_KEY_VALID,"abridged-accounts", descriptionValues,
-                requestParameters);
+                DESCRIPTION_IDENTIFIERS_KEY_VALID,"abridged-accounts", requestParameters);
 
-        assertEquals(POPULATED_RESPONSE, result);
+        assertEquals(RESPONSE_WITH_PLACEHOLDER, result);
     }
 
     @Test
@@ -65,8 +64,7 @@ public class RetrieveApiEnumerationDescriptionTest {
     public void testNullReturnedWhenFileNotFound() throws IOException {
 
         String result = retrieveApiEnumerationDescription.getApiEnumerationDescription(FILING_DESCRIPTIONS_FILE_NAME_INVALID,
-                DESCRIPTION_IDENTIFIERS_KEY_VALID,"abridged-accounts", descriptionValues,
-                requestParameters);
+                DESCRIPTION_IDENTIFIERS_KEY_VALID,"abridged-accounts", requestParameters);
 
         assertEquals(EMPTY_RESPONSE, result);
     }
@@ -76,8 +74,7 @@ public class RetrieveApiEnumerationDescriptionTest {
     public void testNullReturnedWhenDescriptionNotFound() throws IOException {
 
         String result = retrieveApiEnumerationDescription.getApiEnumerationDescription(FILING_DESCRIPTIONS_FILE_NAME_VALID,
-                DESCRIPTION_IDENTIFIERS_KEY_INVALID,"abridged-accounts", descriptionValues,
-               requestParameters);
+                DESCRIPTION_IDENTIFIERS_KEY_INVALID,"abridged-accounts", requestParameters);
 
         assertEquals(EMPTY_RESPONSE, result);
     }

--- a/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentGeneratorServiceTest.java
+++ b/document-generator-api/src/test/java/uk/gov/companieshouse/document/generator/api/service/DocumentGeneratorServiceTest.java
@@ -95,7 +95,7 @@ public class DocumentGeneratorServiceTest {
                 any(Map.class))).thenReturn(setSuccessfulRenderResponse());
         when(mockEnvironmentReader.getMandatoryString(any(String.class))).thenReturn(BUCKET_LOCATION);
         when(mockRetrieveApiEnumerationDescription.getApiEnumerationDescription(any(String.class), any(String.class),
-                any(String.class), any(Map.class), any(Map.class))).thenReturn(DESCRIPTION);
+                any(String.class), any(Map.class))).thenReturn(DESCRIPTION);
 
         ResponseObject response = documentGeneratorService.generate(setValidRequest(), REQUEST_ID);
 
@@ -162,7 +162,7 @@ public class DocumentGeneratorServiceTest {
                 any(Map.class))).thenThrow(IOException.class);
         when(mockEnvironmentReader.getMandatoryString(any(String.class))).thenReturn(BUCKET_LOCATION);
         when(mockRetrieveApiEnumerationDescription.getApiEnumerationDescription(any(String.class), any(String.class),
-                any(String.class), any(Map.class), any(Map.class))).thenReturn(DESCRIPTION);
+                any(String.class), any(Map.class))).thenReturn(DESCRIPTION);
 
         ResponseObject response = documentGeneratorService.generate(setValidRequest(), REQUEST_ID);
 


### PR DESCRIPTION
As the description placeholder population has been moved out of the document-generator, there was an unused parameter on the RetrieveApiEnumerationDescription interface and impl.  