### PR TITLE
Fix missing etag, add logging

### DIFF
--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/ProsecutionDocumentInfoService.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/ProsecutionDocumentInfoService.java
@@ -134,6 +134,10 @@ public class ProsecutionDocumentInfoService implements DocumentInfoService {
                             "Could not get prosecution case info to build template for URI: "
                                             + prosecutionCaseUri,
                             ex, logMap);
+            LOG.errorContext(requestId,
+                            "Could not get prosecution case info to build template for URI, cause: "
+                                            + prosecutionCaseUri,
+                            (Exception) ex.getCause(), logMap);
             throw new DocumentInfoException("Could not build template: " + docGenUri, ex);
         }
     }

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/tmpclient/ProsecutionCase.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/tmpclient/ProsecutionCase.java
@@ -7,6 +7,9 @@ import java.time.LocalDateTime;
 import java.util.Map;
 
 public class ProsecutionCase {
+    @JsonProperty("etag")
+    private String etag;
+
     @JsonProperty("kind")
     private String kind;
 
@@ -93,5 +96,13 @@ public class ProsecutionCase {
 
     public void setLinks(Map<String, String> links) {
         this.links = links;
+    }
+
+    public String getEtag() {
+        return etag;
+    }
+
+    public void setEtag(String etag) {
+        this.etag = etag;
     }
 }


### PR DESCRIPTION
Add etag to ProsecutionCase, improve logging.
ProsecutionCase missing an etag that had been added on the service's ProsecutionCase.

Logging has been improved too, by logging the cause of the SdkException. This is necessary because the structured logging system does not log chained exceptions properly.

Fixes SJP-677