### PR TITLE
Fix missing etag, add logging

### DIFF
--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/ProsecutionDocumentInfoService.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/ProsecutionDocumentInfoService.java
@@ -134,6 +134,10 @@ public class ProsecutionDocumentInfoService implements DocumentInfoService {
                             "Could not get prosecution case info to build template for URI: "
                                             + prosecutionCaseUri,
                             ex, logMap);
+            LOG.errorContext(requestId,
+                            "Could not get prosecution case info to build template for URI, cause: "
+                                            + prosecutionCaseUri,
+                            (Exception) ex.getCause(), logMap);
             throw new DocumentInfoException("Could not build template: " + docGenUri, ex);
         }
     }

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/ProsecutionDocumentInfoService.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/ProsecutionDocumentInfoService.java
@@ -134,10 +134,6 @@ public class ProsecutionDocumentInfoService implements DocumentInfoService {
                             "Could not get prosecution case info to build template for URI: "
                                             + prosecutionCaseUri,
                             ex, logMap);
-            LOG.errorContext(requestId,
-                            "Could not get prosecution case info to build template for URI, cause: "
-                                            + prosecutionCaseUri,
-                            (Exception) ex.getCause(), logMap);
             throw new DocumentInfoException("Could not build template: " + docGenUri, ex);
         }
     }

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/ProsecutionDocumentInfoService.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/ProsecutionDocumentInfoService.java
@@ -34,11 +34,11 @@ import uk.gov.companieshouse.logging.LoggerFactory;
  * <ul>
  * <li>Ultimatum: <code>/prosecution/ultimatum{urlOfProsecutionCase}</code></br>
  * e.g.
- * <code>/prosecution/ultimatum/company/00066516/prosecution-cases/dd908afef2b8529aab3c680239f5d06717113634</code>
+ * <code>/prosecution/ultimatum/company/1/prosecution-cases/dd908afef2b8529aab3c680239f5d06717113634</code>
  * </li>
  * <li>SJP: <code>/prosecution/sjp{urlOfProsecutionCase}</code></br>
  * e.g.
- * <code>/prosecution/sjp/company/00066516/prosecution-cases/dd908afef2b8529aab3c680239f5d06717113634</code>
+ * <code>/prosecution/sjp/company/1/prosecution-cases/dd908afef2b8529aab3c680239f5d06717113634</code>
  * </li>
  * </ul>
  * This service will be matched on the base of this URI, will use the base to further determine
@@ -87,8 +87,12 @@ public class ProsecutionDocumentInfoService implements DocumentInfoService {
     @Override
     public DocumentInfoResponse getDocumentInfo(DocumentInfoRequest documentInfoRequest)
                     throws DocumentInfoException {
-        LOG.info("Started getting document");
+        String resourceUri = documentInfoRequest.getResourceUri();
         String requestId = documentInfoRequest.getRequestId();
+        final Map< String, Object > debugMap = new HashMap< >();
+        debugMap.put("resource_uri", resourceUri);
+        LOG.infoContext(requestId,"Started getting document info", debugMap);
+
         String docGenUri = documentInfoRequest.getResourceUri();
         if (isProsecutionUltimatumRequest(docGenUri)) {
             return getUltimatumInfo(docGenUri, requestId);

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/UltimatumDocumentInfoBuilderProvider.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/UltimatumDocumentInfoBuilderProvider.java
@@ -91,7 +91,8 @@ public class UltimatumDocumentInfoBuilderProvider {
             templateValues.setCompanyName(companyName);
             templateValues.setCompanyNumber(companyIncorporationNumber);
             templateValues.setTemplateRegistryAddress(templateRegistryAddress);
-            templateValues.setDefendantName("David Fraud");
+            //defendant name temporarily WS only, this will vanish in the template rework
+            templateValues.setDefendantName(" ");
             return templateValues;
         }
 
@@ -102,7 +103,8 @@ public class UltimatumDocumentInfoBuilderProvider {
                 return mapper.writeValueAsString(templateValues);
             } catch (JsonProcessingException e) {
                 throw new DocumentInfoCreationException(
-                                "Could not serialise Document Info for Ultimatum");
+                                "Could not serialise Document Info for Ultimatum for prosecution case: "
+                                                + prosecutionCase.getLinks().get("self"));
             }
         }
     }

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/tmpclient/ProsecutionCase.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/tmpclient/ProsecutionCase.java
@@ -7,9 +7,6 @@ import java.time.LocalDateTime;
 import java.util.Map;
 
 public class ProsecutionCase {
-    @JsonProperty("etag")
-    private String etag;
-
     @JsonProperty("kind")
     private String kind;
 
@@ -96,13 +93,5 @@ public class ProsecutionCase {
 
     public void setLinks(Map<String, String> links) {
         this.links = links;
-    }
-
-    public String getEtag() {
-        return etag;
-    }
-
-    public void setEtag(String etag) {
-        this.etag = etag;
     }
 }

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/tmpclient/ProsecutionCase.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/tmpclient/ProsecutionCase.java
@@ -7,6 +7,9 @@ import java.time.LocalDateTime;
 import java.util.Map;
 
 public class ProsecutionCase {
+    @JsonProperty("etag")
+    private String etag;
+
     @JsonProperty("kind")
     private String kind;
 
@@ -93,5 +96,13 @@ public class ProsecutionCase {
 
     public void setLinks(Map<String, String> links) {
         this.links = links;
+    }
+
+    public String getEtag() {
+        return etag;
+    }
+
+    public void setEtag(String etag) {
+        this.etag = etag;
     }
 }

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/tmpclient/ProsecutionCaseStatus.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/tmpclient/ProsecutionCaseStatus.java
@@ -1,10 +1,27 @@
 package uk.gov.companieshouse.document.generator.prosecution.tmpclient;
 
 enum ProsecutionCaseStatus {
-    REFERRED,
-    ACCEPTED,
-    REJECTED;
+    PREPARING("Preparing"),
+    REFERRED("Referred"),
+    ACCEPTED("Accepted"),
+    REJECTED("Rejected"),
+    ULTIMATUM_ISSUED("Ultimatum Issued"),
+    SJPN_ISSUED("SJPN Issued"),
+    OUTCOME_ENTERED("Outcome Entered"),
+    CLOSED("Closed"),
+    ADJOURNED("Adjourned"),
+    RESTARTED("Restarted"),
+    REOPENED("Reopened"),
+    APPEALED("Appealed"),
+    POST_CONVICTION("Post Conviction");
 
-    ProsecutionCaseStatus() {
+    private String value;
+    
+    ProsecutionCaseStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
     }
 }


### PR DESCRIPTION
Add etag to ProsecutionCase, improve logging.
ProsecutionCase missing an etag that had been added on the service's ProsecutionCase.

Logging has been improved too, by logging the cause of the SdkException. This is necessary because the structured logging system does not log chained exceptions properly.

Fixes SJP-677