### PR TITLE
Add transformer for prosecution case

### DIFF
--- a/document-generator-prosecution/pom.xml
+++ b/document-generator-prosecution/pom.xml
@@ -26,7 +26,7 @@
 
         <!--Dependencies-->
         <spring-boot-start-web.version>2.0.4.RELEASE</spring-boot-start-web.version>
-        <api-sdk-java.version>3.13.12</api-sdk-java.version>
+        <private-api-sdk-java.version>1.2.10</private-api-sdk-java.version>
         <environment-reader-library.version>1.2.0-rc1</environment-reader-library.version>
         <structured-logging.version>1.3.0-rc1</structured-logging.version>
 
@@ -38,8 +38,8 @@
     <dependencies>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
-            <artifactId>api-sdk-java</artifactId>
-            <version>${api-sdk-java.version}</version>
+            <artifactId>private-api-sdk-java</artifactId>
+            <version>${private-api-sdk-java.version}</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/ProsecutionDocumentInfoService.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/ProsecutionDocumentInfoService.java
@@ -9,7 +9,7 @@ import uk.gov.companieshouse.document.generator.interfaces.exception.DocumentInf
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoRequest;
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoResponse;
 import uk.gov.companieshouse.document.generator.prosecution.UltimatumDocumentInfoBuilderProvider.UltimatumDocumentInfoBuilder;
-import uk.gov.companieshouse.document.generator.prosecution.tmpclient.ProsecutionCase;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.model.prosecutioncase.ProsecutionCase;
 import uk.gov.companieshouse.document.generator.prosecution.tmpclient.ProsecutionClient;
 import uk.gov.companieshouse.document.generator.prosecution.tmpclient.SdkException;
 import uk.gov.companieshouse.logging.Logger;

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/UltimatumDocumentInfoBuilderProvider.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/UltimatumDocumentInfoBuilderProvider.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoResponse;
-import uk.gov.companieshouse.document.generator.prosecution.tmpclient.ProsecutionCase;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.model.prosecutioncase.ProsecutionCase;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 
 /**

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/mappers/ApiToProsecutionCaseMapper.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/mappers/ApiToProsecutionCaseMapper.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.document.generator.prosecution.mapping.mappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.springframework.web.context.annotation.RequestScope;
+import uk.gov.companieshouse.api.model.prosecution.prosecutioncase.ProsecutionCaseApi;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.model.prosecutioncase.ProsecutionCase;
+
+@RequestScope
+@Mapper(componentModel = "spring")
+public interface ApiToProsecutionCaseMapper {
+
+    @Mappings({
+            @Mapping(source = "prosecutionCase.status", target ="status"),
+            @Mapping(source = "prosecutionCase.companyIncorporationNumber", target = "companyIncorporationNumber"),
+            @Mapping(source = "prosecutionCase.companyName", target = "companyName"),
+            @Mapping(source = "prosecutionCase.complianceCaseId", target = "complianceCaseId"),
+            @Mapping(source = "prosecutionCase.complianceUserId", target = "complianceUserId"),
+            @Mapping(source = "prosecutionCase.submittedAt", target = "submittedAt"),
+            @Mapping(source = "prosecutionCase.links", target = "links")
+    })
+    ProsecutionCase apiToProsecutionCase(ProsecutionCaseApi prosecutionCase);
+}

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/model/prosecutioncase/ProsecutionCase.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/model/prosecutioncase/ProsecutionCase.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.document.generator.prosecution.tmpclient;
+package uk.gov.companieshouse.document.generator.prosecution.mapping.model.prosecutioncase;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/model/prosecutioncase/ProsecutionCaseStatus.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/model/prosecutioncase/ProsecutionCaseStatus.java
@@ -1,6 +1,6 @@
-package uk.gov.companieshouse.document.generator.prosecution.tmpclient;
+package uk.gov.companieshouse.document.generator.prosecution.mapping.model.prosecutioncase;
 
-enum ProsecutionCaseStatus {
+public enum ProsecutionCaseStatus {
     PREPARING("Preparing"),
     REFERRED("Referred"),
     ACCEPTED("Accepted"),

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/tmpclient/ProsecutionClient.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/tmpclient/ProsecutionClient.java
@@ -11,6 +11,7 @@ import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.companieshouse.document.generator.prosecution.ConfigKeys;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.model.prosecutioncase.ProsecutionCase;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;

--- a/document-generator-prosecution/src/test/java/uk/gov/companieshouse/document/generator/prosecution/ProsecutionDocumentInfoServiceTest.java
+++ b/document-generator-prosecution/src/test/java/uk/gov/companieshouse/document/generator/prosecution/ProsecutionDocumentInfoServiceTest.java
@@ -14,7 +14,7 @@ import uk.gov.companieshouse.document.generator.interfaces.exception.DocumentInf
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoRequest;
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoResponse;
 import uk.gov.companieshouse.document.generator.prosecution.UltimatumDocumentInfoBuilderProvider.UltimatumDocumentInfoBuilder;
-import uk.gov.companieshouse.document.generator.prosecution.tmpclient.ProsecutionCase;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.model.prosecutioncase.ProsecutionCase;
 import uk.gov.companieshouse.document.generator.prosecution.tmpclient.ProsecutionClient;
 import uk.gov.companieshouse.document.generator.prosecution.tmpclient.SdkException;
 

--- a/document-generator-prosecution/src/test/java/uk/gov/companieshouse/document/generator/prosecution/UltimatumDocumentInfoBuilderProviderTest.java
+++ b/document-generator-prosecution/src/test/java/uk/gov/companieshouse/document/generator/prosecution/UltimatumDocumentInfoBuilderProviderTest.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.document.generator.interfaces.model.DocumentInfoResponse;
 import uk.gov.companieshouse.document.generator.prosecution.UltimatumDocumentInfoBuilderProvider.UltimatumDocumentInfoBuilder;
-import uk.gov.companieshouse.document.generator.prosecution.tmpclient.ProsecutionCase;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.model.prosecutioncase.ProsecutionCase;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 
 @ExtendWith(MockitoExtension.class)

--- a/document-generator-prosecution/src/test/java/uk/gov/companieshouse/document/generator/prosecution/mapping/ApiToProsecutionCaseMapperTest.java
+++ b/document-generator-prosecution/src/test/java/uk/gov/companieshouse/document/generator/prosecution/mapping/ApiToProsecutionCaseMapperTest.java
@@ -1,0 +1,69 @@
+package uk.gov.companieshouse.document.generator.prosecution.mapping;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.prosecution.prosecutioncase.ProsecutionCaseApi;
+import uk.gov.companieshouse.api.model.prosecution.prosecutioncase.ProsecutionCaseStatus;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.mappers.ApiToProsecutionCaseMapper;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.mappers.ApiToProsecutionCaseMapperImpl;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.model.prosecutioncase.ProsecutionCase;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ApiToProsecutionCaseMapperTest {
+
+    private ApiToProsecutionCaseMapper apiToProsecutionCaseMapper =
+            new ApiToProsecutionCaseMapperImpl();
+
+    private static final String KIND = "kind";
+    private static final ProsecutionCaseStatus STATUS = ProsecutionCaseStatus.ACCEPTED;
+    private static final String COMPANY_INCORPORATION_NUMBER = "companyIncorporationNumber";
+    private static final String COMPANY_NAME = "companyName";
+    private static final String COMPLIANCE_CASE_ID = "complianceCaseId";
+    private static final String COMPLIANCE_USER_ID = "complianceUserId";
+    private static final LocalDateTime SUBMITTED_AT = LocalDateTime.now();
+    private static final Map<String, String> LINKS = new HashMap<>();
+
+    @Test
+    @DisplayName("Tests prosecution case API values map to prosecution case DocGen model")
+    void testApiToProsecutionCaseMaps() {
+        ProsecutionCase prosecutionCase =
+                apiToProsecutionCaseMapper.apiToProsecutionCase(createProsecutionCase());
+
+        assertNotNull(prosecutionCase);
+        assertEquals(KIND, prosecutionCase.getKind());
+        assertEquals(
+                uk.gov.companieshouse.document.generator.prosecution.mapping.model.prosecutioncase.ProsecutionCaseStatus.ACCEPTED,
+                prosecutionCase.getStatus());
+        assertEquals(COMPANY_INCORPORATION_NUMBER, prosecutionCase.getCompanyIncorporationNumber());
+        assertEquals(COMPANY_NAME, prosecutionCase.getCompanyName());
+        assertEquals(COMPLIANCE_CASE_ID, prosecutionCase.getComplianceCaseId());
+        assertEquals(COMPLIANCE_USER_ID, prosecutionCase.getComplianceUserId());
+        assertEquals(SUBMITTED_AT, prosecutionCase.getSubmittedAt());
+        assertEquals(LINKS, prosecutionCase.getLinks());
+    }
+
+    private ProsecutionCaseApi createProsecutionCase() {
+        ProsecutionCaseApi prosecutionCase = new ProsecutionCaseApi();
+        prosecutionCase.setKind(KIND);
+        prosecutionCase.setStatus(STATUS);
+        prosecutionCase.setCompanyIncorporationNumber(COMPANY_INCORPORATION_NUMBER);
+        prosecutionCase.setCompanyName(COMPANY_NAME);
+        prosecutionCase.setComplianceCaseId(COMPLIANCE_CASE_ID);
+        prosecutionCase.setComplianceUserId(COMPLIANCE_USER_ID);
+        prosecutionCase.setSubmittedAt(SUBMITTED_AT);
+        prosecutionCase.setLinks(LINKS);
+
+        return prosecutionCase;
+    }
+}


### PR DESCRIPTION
The ProsecutionCase models already part of the codebase has been
moved to the appropriate location. A mapper to transform the model in
the SDK to the models in DocGen. All other changes were included as
part of the refactor when the ProsecutionCase model was moved.

Resolves SJP-691