### PR TITLE
Add transformer for defendant

### DIFF
--- a/document-generator-prosecution/pom.xml
+++ b/document-generator-prosecution/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>document-generator-interfaces</artifactId>
-            <version>5f53c6f</version>
+            <version>unversioned</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/document-generator-prosecution/pom.xml
+++ b/document-generator-prosecution/pom.xml
@@ -26,7 +26,7 @@
 
         <!--Dependencies-->
         <spring-boot-start-web.version>2.0.4.RELEASE</spring-boot-start-web.version>
-        <private-api-sdk-java.version>1.2.10</private-api-sdk-java.version>
+        <private-api-sdk-java.version>1.2.11</private-api-sdk-java.version>
         <environment-reader-library.version>1.2.0-rc1</environment-reader-library.version>
         <structured-logging.version>1.3.0-rc1</structured-logging.version>
 
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>document-generator-interfaces</artifactId>
-            <version>unversioned</version>
+            <version>5f53c6f</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/mappers/ApiToDefendantMapper.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/mappers/ApiToDefendantMapper.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.document.generator.prosecution.mapping.mappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.springframework.web.context.annotation.RequestScope;
+import uk.gov.companieshouse.api.model.prosecution.defendant.DefendantApi;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.model.defendant.Defendant;
+
+@RequestScope
+@Mapper(componentModel = "spring")
+public interface ApiToDefendantMapper {
+    @Mappings({
+            @Mapping(source = "defendant.officerId", target = "officerId"),
+            @Mapping(source = "defendant.addressApi", target = "address"),
+            @Mapping(source = "defendant.personOfficerDetailsApi", target = "personOfficerDetails"),
+            @Mapping(source = "defendant.companyOfficerDetailsApi", target = "companyOfficerDetails"),
+            @Mapping(source = "defendant.dateAppointedOn", target = "dateAppointedOn"),
+            @Mapping(source = "defendant.dateTerminatedOn", target = "dateTerminatedOn"),
+            @Mapping(source = "defendant.isCorporateAppointment", target = "isCorporateAppointment")
+    })
+    Defendant apiToDefendant(DefendantApi defendant);
+}
+

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/model/defendant/Address.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/model/defendant/Address.java
@@ -1,0 +1,95 @@
+package uk.gov.companieshouse.document.generator.prosecution.mapping.model.defendant;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Address {
+    @JsonProperty("house_name_number")
+    private String houseNameNumber;
+
+    @JsonProperty("street")
+    private String street;
+
+    @JsonProperty("area")
+    private String area;
+
+    @JsonProperty("town")
+    private String postTown;
+
+    @JsonProperty("region")
+    private String region;
+
+    @JsonProperty("country")
+    private String country;
+
+    @JsonProperty("postcode")
+    private String postCode;
+
+    public Address() {
+    }
+
+    public Address(String houseNameNumber, String street, String area, String postTown, String region, String country, String postCode) {
+        this.houseNameNumber = houseNameNumber;
+        this.street = street;
+        this.area = area;
+        this.postTown = postTown;
+        this.region = region;
+        this.country = country;
+        this.postCode = postCode;
+    }
+
+    public String getHouseNameNumber() {
+        return houseNameNumber;
+    }
+
+    public void setHouseNameNumber(String houseNamenumber) {
+        this.houseNameNumber = houseNamenumber;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+
+    public String getArea() {
+        return area;
+    }
+
+    public void setArea(String area) {
+        this.area = area;
+    }
+
+    public String getPostTown() {
+        return postTown;
+    }
+
+    public void setPostTown(String postTown) {
+        this.postTown = postTown;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public String getPostCode() {
+        return postCode;
+    }
+
+    public void setPostCode(String postCode) {
+        this.postCode = postCode;
+    }
+}

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/model/defendant/CompanyOfficerDetails.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/model/defendant/CompanyOfficerDetails.java
@@ -1,0 +1,16 @@
+package uk.gov.companieshouse.document.generator.prosecution.mapping.model.defendant;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CompanyOfficerDetails {
+    @JsonProperty("company_name")
+    private String companyName;
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
+    }
+}

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/model/defendant/Defendant.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/model/defendant/Defendant.java
@@ -1,0 +1,96 @@
+package uk.gov.companieshouse.document.generator.prosecution.mapping.model.defendant;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+public class Defendant {
+    @JsonProperty("officer_id")
+    private String officerId;
+
+    @JsonProperty("address")
+    private Address address;
+
+    @JsonProperty("person_officer_details")
+    PersonOfficerDetails personOfficerDetails;
+
+    @JsonProperty("company_officer_details")
+    CompanyOfficerDetails companyOfficerDetails;
+
+    @JsonProperty("date_appointed_on")
+    private LocalDate dateAppointedOn;
+
+    @JsonProperty("date_terminated_on")
+    private LocalDate dateTerminatedOn;
+
+    @JsonProperty("appointment_type")
+    private String appointmentType;
+
+    @JsonProperty("is_corporate_appointment")
+    private Boolean isCorporateAppointment;
+
+    public String getOfficerId() {
+        return officerId;
+    }
+
+    public void setOfficerId(String officerId) {
+        this.officerId = officerId;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    public PersonOfficerDetails getPersonOfficerDetails() {
+        return personOfficerDetails;
+    }
+
+    public void setPersonOfficerDetails(PersonOfficerDetails personOfficerDetails) {
+        this.personOfficerDetails = personOfficerDetails;
+    }
+
+    public CompanyOfficerDetails getCompanyOfficerDetails() {
+        return companyOfficerDetails;
+    }
+
+    public void setCompanyOfficerDetails(CompanyOfficerDetails companyOfficerDetails) {
+        this.companyOfficerDetails = companyOfficerDetails;
+    }
+
+    public LocalDate getDateAppointedOn() {
+        return dateAppointedOn;
+    }
+
+    public void setDateAppointedOn(LocalDate dateAppointedOn) {
+        this.dateAppointedOn = dateAppointedOn;
+    }
+
+    public LocalDate getDateTerminatedOn() {
+        return dateTerminatedOn;
+    }
+
+    public void setDateTerminatedOn(LocalDate dateTerminatedOn) {
+        this.dateTerminatedOn = dateTerminatedOn;
+    }
+
+    public String getAppointmentType() {
+        return appointmentType;
+    }
+
+    public void setAppointmentType(String appointmentType) {
+        this.appointmentType = appointmentType;
+    }
+
+    public Boolean getIsCorporateAppointment() {
+        return isCorporateAppointment;
+    }
+
+    public void setIsCorporateAppointment(Boolean isCorporateAppointment) {
+        this.isCorporateAppointment = isCorporateAppointment;
+    }
+}

--- a/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/model/defendant/PersonOfficerDetails.java
+++ b/document-generator-prosecution/src/main/java/uk/gov/companieshouse/document/generator/prosecution/mapping/model/defendant/PersonOfficerDetails.java
@@ -1,0 +1,64 @@
+package uk.gov.companieshouse.document.generator.prosecution.mapping.model.defendant;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+
+public class PersonOfficerDetails {
+
+    @JsonProperty("title")
+    private String title;
+
+    @JsonProperty("forename")
+    private String forename;
+
+    @JsonProperty("middle_name")
+    private String middleName;
+
+    @JsonProperty("surname")
+    private String surname;
+
+    @JsonProperty("date_of_birth")
+    private LocalDate dateOfBirth;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getForename() {
+        return forename;
+    }
+
+    public void setForename(String forename) {
+        this.forename = forename;
+    }
+
+    public String getMiddleName() {
+        return middleName;
+    }
+
+    public void setMiddleName(String middleName) {
+        this.middleName = middleName;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public LocalDate getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(LocalDate dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+}

--- a/document-generator-prosecution/src/test/java/uk/gov/companieshouse/document/generator/prosecution/mapping/ApiToDefendantMapperTest.java
+++ b/document-generator-prosecution/src/test/java/uk/gov/companieshouse/document/generator/prosecution/mapping/ApiToDefendantMapperTest.java
@@ -11,14 +11,9 @@ import uk.gov.companieshouse.api.model.prosecution.defendant.DefendantApi;
 import uk.gov.companieshouse.api.model.prosecution.defendant.PersonOfficerDetailsApi;
 import uk.gov.companieshouse.document.generator.prosecution.mapping.mappers.ApiToDefendantMapper;
 import uk.gov.companieshouse.document.generator.prosecution.mapping.mappers.ApiToDefendantMapperImpl;
-import uk.gov.companieshouse.document.generator.prosecution.mapping.model.defendant.Address;
-import uk.gov.companieshouse.document.generator.prosecution.mapping.model.defendant.CompanyOfficerDetails;
 import uk.gov.companieshouse.document.generator.prosecution.mapping.model.defendant.Defendant;
-import uk.gov.companieshouse.document.generator.prosecution.mapping.model.defendant.PersonOfficerDetails;
 
 import java.time.LocalDate;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -51,7 +46,8 @@ public class ApiToDefendantMapperTest {
         assertEquals(ADDRESS.getArea(), defendant.getAddress().getArea());
         assertEquals(ADDRESS.getPostTown(), defendant.getAddress().getPostTown());
         assertEquals(ADDRESS.getRegion(), defendant.getAddress().getRegion());
-        assertEquals(ADDRESS.getRegion(), defendant.getAddress().getRegion());
+        assertEquals(ADDRESS.getCountry(), defendant.getAddress().getCountry());
+        assertEquals(ADDRESS.getPostCode(), defendant.getAddress().getPostCode());
         assertEquals(PERSON_OFFICER_DETAILS.getDateOfBirth(), defendant.getPersonOfficerDetails().getDateOfBirth());
         assertEquals(PERSON_OFFICER_DETAILS.getTitle(), defendant.getPersonOfficerDetails().getTitle());
         assertEquals(PERSON_OFFICER_DETAILS.getForename(), defendant.getPersonOfficerDetails().getForename());

--- a/document-generator-prosecution/src/test/java/uk/gov/companieshouse/document/generator/prosecution/mapping/ApiToDefendantMapperTest.java
+++ b/document-generator-prosecution/src/test/java/uk/gov/companieshouse/document/generator/prosecution/mapping/ApiToDefendantMapperTest.java
@@ -1,0 +1,87 @@
+package uk.gov.companieshouse.document.generator.prosecution.mapping;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.prosecution.defendant.AddressApi;
+import uk.gov.companieshouse.api.model.prosecution.defendant.CompanyOfficerDetailsApi;
+import uk.gov.companieshouse.api.model.prosecution.defendant.DefendantApi;
+import uk.gov.companieshouse.api.model.prosecution.defendant.PersonOfficerDetailsApi;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.mappers.ApiToDefendantMapper;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.mappers.ApiToDefendantMapperImpl;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.model.defendant.Address;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.model.defendant.CompanyOfficerDetails;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.model.defendant.Defendant;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.model.defendant.PersonOfficerDetails;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ApiToDefendantMapperTest {
+
+    private ApiToDefendantMapper apiToDefendantMapper = new ApiToDefendantMapperImpl();
+
+    private static final String OFFICER_ID = "officerId";
+    private static final AddressApi ADDRESS =
+            new AddressApi("1", "street", "area", "town", "region", "country", "postcode");
+    private static final PersonOfficerDetailsApi PERSON_OFFICER_DETAILS = new PersonOfficerDetailsApi();
+    private static final CompanyOfficerDetailsApi COMPANY_OFFICER_DETAILS = new CompanyOfficerDetailsApi();
+    private static final LocalDate DATE_APPOINTED_ON = LocalDate.now();
+    private static final LocalDate DATE_TERMINATED_ON = LocalDate.now();
+    private static final String APPOINTMENT_TYPE = "appointmentType";
+    private static final boolean IS_CORPORATE_APPOINTMENT = true;
+
+    @Test
+    @DisplayName("Tests defendant API values map to defendant DocGen model")
+    void testApiToDefendantMaps() {
+        Defendant defendant = apiToDefendantMapper.apiToDefendant(createDefendant());
+
+        assertNotNull(defendant);
+        assertEquals(OFFICER_ID, defendant.getOfficerId());
+        assertEquals(ADDRESS.getHouseNameNumber(), defendant.getAddress().getHouseNameNumber());
+        assertEquals(ADDRESS.getStreet(), defendant.getAddress().getStreet());
+        assertEquals(ADDRESS.getArea(), defendant.getAddress().getArea());
+        assertEquals(ADDRESS.getPostTown(), defendant.getAddress().getPostTown());
+        assertEquals(ADDRESS.getRegion(), defendant.getAddress().getRegion());
+        assertEquals(ADDRESS.getRegion(), defendant.getAddress().getRegion());
+        assertEquals(PERSON_OFFICER_DETAILS.getDateOfBirth(), defendant.getPersonOfficerDetails().getDateOfBirth());
+        assertEquals(PERSON_OFFICER_DETAILS.getTitle(), defendant.getPersonOfficerDetails().getTitle());
+        assertEquals(PERSON_OFFICER_DETAILS.getForename(), defendant.getPersonOfficerDetails().getForename());
+        assertEquals(PERSON_OFFICER_DETAILS.getMiddleName(), defendant.getPersonOfficerDetails().getMiddleName());
+        assertEquals(PERSON_OFFICER_DETAILS.getSurname(), defendant.getPersonOfficerDetails().getSurname());
+        assertEquals(COMPANY_OFFICER_DETAILS.getCompanyName(), defendant.getCompanyOfficerDetails().getCompanyName());
+        assertEquals(APPOINTMENT_TYPE, defendant.getAppointmentType());
+        assertEquals(IS_CORPORATE_APPOINTMENT, defendant.getIsCorporateAppointment());
+    }
+
+    private DefendantApi createDefendant() {
+        DefendantApi defendant = new DefendantApi();
+
+        PERSON_OFFICER_DETAILS.setTitle("title");
+        PERSON_OFFICER_DETAILS.setForename("forename");
+        PERSON_OFFICER_DETAILS.setMiddleName("middlename");
+        PERSON_OFFICER_DETAILS.setSurname("surname");
+        PERSON_OFFICER_DETAILS.setDateOfBirth(LocalDate.now());
+
+        COMPANY_OFFICER_DETAILS.setCompanyName("companyName");
+
+        defendant.setOfficerId(OFFICER_ID);
+        defendant.setAddressApi(ADDRESS);
+        defendant.setPersonOfficerDetailsApi(PERSON_OFFICER_DETAILS);
+        defendant.setCompanyOfficerDetailsApi(COMPANY_OFFICER_DETAILS);
+        defendant.setDateAppointedOn(DATE_APPOINTED_ON);
+        defendant.setDateTerminatedOn(DATE_TERMINATED_ON);
+        defendant.setAppointmentType(APPOINTMENT_TYPE);
+        defendant.setIsCorporateAppointment(IS_CORPORATE_APPOINTMENT);
+
+        return defendant;
+    }
+}

--- a/document-generator-prosecution/src/test/java/uk/gov/companieshouse/document/generator/prosecution/mapping/ApiToProsecutionCaseMapperTest.java
+++ b/document-generator-prosecution/src/test/java/uk/gov/companieshouse/document/generator/prosecution/mapping/ApiToProsecutionCaseMapperTest.java
@@ -6,10 +6,11 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.model.prosecution.prosecutioncase.ProsecutionCaseApi;
-import uk.gov.companieshouse.api.model.prosecution.prosecutioncase.ProsecutionCaseStatus;
+import uk.gov.companieshouse.api.model.prosecution.prosecutioncase.ProsecutionCaseStatusApi;
 import uk.gov.companieshouse.document.generator.prosecution.mapping.mappers.ApiToProsecutionCaseMapper;
 import uk.gov.companieshouse.document.generator.prosecution.mapping.mappers.ApiToProsecutionCaseMapperImpl;
 import uk.gov.companieshouse.document.generator.prosecution.mapping.model.prosecutioncase.ProsecutionCase;
+import uk.gov.companieshouse.document.generator.prosecution.mapping.model.prosecutioncase.ProsecutionCaseStatus;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -26,7 +27,7 @@ public class ApiToProsecutionCaseMapperTest {
             new ApiToProsecutionCaseMapperImpl();
 
     private static final String KIND = "kind";
-    private static final ProsecutionCaseStatus STATUS = ProsecutionCaseStatus.ACCEPTED;
+    private static final ProsecutionCaseStatusApi STATUS = ProsecutionCaseStatusApi.ACCEPTED;
     private static final String COMPANY_INCORPORATION_NUMBER = "companyIncorporationNumber";
     private static final String COMPANY_NAME = "companyName";
     private static final String COMPLIANCE_CASE_ID = "complianceCaseId";
@@ -42,9 +43,7 @@ public class ApiToProsecutionCaseMapperTest {
 
         assertNotNull(prosecutionCase);
         assertEquals(KIND, prosecutionCase.getKind());
-        assertEquals(
-                uk.gov.companieshouse.document.generator.prosecution.mapping.model.prosecutioncase.ProsecutionCaseStatus.ACCEPTED,
-                prosecutionCase.getStatus());
+        assertEquals(ProsecutionCaseStatus.ACCEPTED, prosecutionCase.getStatus());
         assertEquals(COMPANY_INCORPORATION_NUMBER, prosecutionCase.getCompanyIncorporationNumber());
         assertEquals(COMPANY_NAME, prosecutionCase.getCompanyName());
         assertEquals(COMPLIANCE_CASE_ID, prosecutionCase.getComplianceCaseId());


### PR DESCRIPTION
Defendant models for DocGen have been added, and the SDK version has
also been changed in the Prosecution POM. As a result of this, a unit
test for the ProsecutionCase transformer also had to be changed. The
defendant mapper has also been added for transforming the SDK models
to those in DocGen.

Resolves SJP-692