### PR TITLE
Correct accounts heading for overseas company account dates 

### DIFF
--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -168,7 +168,7 @@
                 {{if eq $foreignCompanyDetails.accounting_requirements.terms_of_account_publication "accounting-publication-date-does-not-need-to-be-supplied-by-company"}}
 
                     {{if $keyFilingDates.last_accounts_made_up_to}}
-                        <h3 class="heading-small">Accounts</h3>
+                        <h3 class="heading-small">Key filing dates</h3>
                         Last accounts made up to: {{$keyFilingDates.last_accounts_made_up_to}}
                     {{end}}
 
@@ -176,7 +176,7 @@
 
                 {{if eq $foreignCompanyDetails.accounting_requirements.terms_of_account_publication "accounts-publication-date-supplied-by-company"}}
 
-                    <h3 class="heading-small">Accounts</h3>
+                    <h3 class="heading-small">Key filing dates</h3>
                     {{if $foreignCompanyDetails.accounts}}
                         <p>Required to publish accounts from {{$foreignCompanyDetails.accounts.account_period_from.day}}
                             {{$foreignCompanyDetails.accounts.account_period_from.month}} to {{$foreignCompanyDetails.accounts.account_period_to.day}}
@@ -195,7 +195,7 @@
                 {{ if eq $foreignCompanyDetails.accounting_requirements.terms_of_account_publication "accounting-reference-date-allocated-by-companies-house"}}
 
                     {{if or $keyFilingDates.next_made_up_to $keyFilingDates.last_accounts_made_up_to}}
-                        <h3 class="heading-small">Accounts</h3>
+                        <h3 class="heading-small">Key filing dates</h3>
                     {{end}}
 
                     {{if $keyFilingDates.next_made_up_to}}


### PR DESCRIPTION
Correct accounts heading for overseas company account dates to display 'Key filing dates' rather than 'accounts'

Resolves : PCI-168