### PR TITLE
Company Report Insolvency mapping

### DIFF
--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/handler/CompanyReportDataHandler.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/handler/CompanyReportDataHandler.java
@@ -314,7 +314,7 @@ public class CompanyReportDataHandler {
                     .collect(Collectors.toList());
                 cases.setDates(dates);
                 List<PractitionerApi> practitioners = cases.getPractitioners().stream()
-                    .sorted(Comparator.comparing(PractitionerApi::getCeasedToActOn, Comparator.nullsFirst(Comparator.reverseOrder())))
+                    .sorted(Comparator.comparing(PractitionerApi::getCeasedToActOn, Comparator.nullsLast(Comparator.reverseOrder())))
                     .collect(Collectors.toList());
                 cases.setPractitioners(practitioners);
                 return cases;

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/handler/CompanyReportDataHandler.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/handler/CompanyReportDataHandler.java
@@ -310,11 +310,12 @@ public class CompanyReportDataHandler {
             .sorted(Comparator.comparing(CaseApi::getNumber, Comparator.nullsLast(Comparator.reverseOrder())))
             .map(cases -> {
                 List<DatesApi> dates = cases.getDates().stream()
-                    .sorted(Comparator.comparing(DatesApi::getDate, Comparator.nullsLast(Comparator.reverseOrder())))
+                    .sorted(Comparator.comparing(DatesApi::getDate, Comparator.nullsLast(Comparator.naturalOrder())))
                     .collect(Collectors.toList());
                 cases.setDates(dates);
                 List<PractitionerApi> practitioners = cases.getPractitioners().stream()
-                    .sorted(Comparator.comparing(PractitionerApi::getCeasedToActOn, Comparator.nullsLast(Comparator.reverseOrder())))
+                    .sorted(Comparator.comparing(PractitionerApi::getCeasedToActOn, Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(PractitionerApi::getAppointedOn, Comparator.nullsLast(Comparator.reverseOrder())))
                     .collect(Collectors.toList());
                 cases.setPractitioners(practitioners);
                 return cases;

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/CompanyReportMapperDecorator.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/CompanyReportMapperDecorator.java
@@ -6,11 +6,13 @@ import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.company.PreviousCompanyNamesApi;
 import uk.gov.companieshouse.api.model.company.foreigncompany.ForeignCompanyDetailsApi;
 import uk.gov.companieshouse.api.model.filinghistory.FilingApi;
+import uk.gov.companieshouse.api.model.insolvency.InsolvencyApi;
 import uk.gov.companieshouse.api.model.officers.OfficersApi;
 import uk.gov.companieshouse.api.model.psc.PscsApi;
 import uk.gov.companieshouse.api.model.statements.StatementsApi;
 import uk.gov.companieshouse.document.generator.company.report.mapping.mappers.currentappointments.ApiToCurrentAppointmentsMapper;
 import uk.gov.companieshouse.document.generator.company.report.mapping.mappers.foreigncompanydetails.ApiToForeignCompanyDetailsMapper;
+import uk.gov.companieshouse.document.generator.company.report.mapping.mappers.insolvency.ApiToInsolvencyMapper;
 import uk.gov.companieshouse.document.generator.company.report.mapping.mappers.keyfilingdates.ApiToKeyFilingDatesMapper;
 import uk.gov.companieshouse.document.generator.company.report.mapping.mappers.previousnames.ApiToPreviousNamesMapper;
 import uk.gov.companieshouse.document.generator.company.report.mapping.mappers.pscs.ApiToPscsMapper;
@@ -21,6 +23,7 @@ import uk.gov.companieshouse.document.generator.company.report.mapping.model.Com
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.CompanyReport;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.currentappointments.CurrentAppointments;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.foreigncompanydetails.ForeignCompanyDetails;
+import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.Insolvency;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.keyfilingdates.KeyFilingDates;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.previousnames.PreviousNames;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.pscs.Pscs;
@@ -65,6 +68,9 @@ public class CompanyReportMapperDecorator implements CompanyReportMapper {
 
     @Autowired
     private ApiToPscStatementsMapper apiToPscStatementsMapper;
+
+    @Autowired
+    private ApiToInsolvencyMapper apiToInsolvencyMapper;
 
     private static final Logger LOG = LoggerFactory.getLogger(MODULE_NAME_SPACE);
 
@@ -112,6 +118,11 @@ public class CompanyReportMapperDecorator implements CompanyReportMapper {
                 companyReport.setForeignCompanyDetails(setForeignCompanyDetails(companyReportApiData
                     .getCompanyProfileApi().getForeignCompanyDetails()));
             }
+
+            if (companyReportApiData.getInsolvencyApi() != null) {
+                LOG.infoContext(requestId, "Map data for insolvency", getDebugMap(companyNumber));
+                companyReport.setInsolvency(setInsolvency(companyReportApiData.getInsolvencyApi()));
+            }
         }
 
         return companyReport;
@@ -147,6 +158,10 @@ public class CompanyReportMapperDecorator implements CompanyReportMapper {
 
     private ForeignCompanyDetails setForeignCompanyDetails(ForeignCompanyDetailsApi foreignCompanyDetailsApi) {
         return apiToForeignCompanyDetailsMapper.apiToForeignCompanyDetails(foreignCompanyDetailsApi);
+    }
+
+    private Insolvency setInsolvency(InsolvencyApi insolvencyApi) {
+        return apiToInsolvencyMapper.apiToInsolvencyMapper(insolvencyApi);
     }
 
     private Map<String, Object> getDebugMap(String companyNumber) {

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToCaseMapper.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToCaseMapper.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.document.generator.company.report.mapping.mappers.insolvency;
+
+import org.mapstruct.Mapper;
+import org.springframework.web.context.annotation.RequestScope;
+import uk.gov.companieshouse.api.model.insolvency.CaseApi;
+import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items.InsolvencyCase;
+
+import java.util.List;
+
+@RequestScope
+@Mapper(componentModel = "spring", uses = {ApiToPractitionerMapper.class})
+public interface ApiToCaseMapper {
+
+    InsolvencyCase apiToCaseMapper(CaseApi caseApi);
+
+    List<InsolvencyCase> apiToCaseMapper(List<CaseApi> caseApis);
+}

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToCaseMapper.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToCaseMapper.java
@@ -8,10 +8,8 @@ import org.mapstruct.Mappings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.companieshouse.api.model.insolvency.CaseApi;
-import uk.gov.companieshouse.api.model.insolvency.DatesApi;
 import uk.gov.companieshouse.document.generator.common.descriptions.RetrieveApiEnumerationDescription;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items.InsolvencyCase;
-import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items.InsolvencyDate;
 
 import java.util.HashMap;
 import java.util.List;

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToInsolvencyDateMapper.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToInsolvencyDateMapper.java
@@ -7,43 +7,56 @@ import org.mapstruct.MappingTarget;
 import org.mapstruct.Mappings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.context.annotation.RequestScope;
-import uk.gov.companieshouse.api.model.insolvency.CaseApi;
 import uk.gov.companieshouse.api.model.insolvency.DatesApi;
 import uk.gov.companieshouse.document.generator.common.descriptions.RetrieveApiEnumerationDescription;
-import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items.InsolvencyCase;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items.InsolvencyDate;
 
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 @RequestScope
-@Mapper(componentModel = "spring", uses = {ApiToPractitionerMapper.class, ApiToInsolvencyDateMapper.class})
-public abstract class ApiToCaseMapper {
+@Mapper(componentModel = "spring")
+public abstract class ApiToInsolvencyDateMapper {
 
     @Autowired
     private RetrieveApiEnumerationDescription retrieveApiEnumerationDescription;
 
     private static final String CONSTANTS = "constants";
-    private static final String INSOLVENCY_CASE_TYPE = "insolvency_case_type";
+    private static final String INSOLVENCY_CASE_DATE_TYPE = "insolvency_case_date_type";
     private static final String ENUMERATION_MAPPING = "Enumeration mapping :";
 
+    private static final String D_MMMM_UUUU = "d MMMM uuuu";
 
     @Mappings({
+        @Mapping(target = "date", ignore = true),
         @Mapping(target = "type", ignore = true)
     })
-    public abstract InsolvencyCase apiToCaseMapper(CaseApi caseApi);
+    public abstract InsolvencyDate apiToInsolvencyDateMapper(DatesApi datesApi);
 
-    public abstract List<InsolvencyCase> apiToCaseMapper(List<CaseApi> caseApis);
+    public abstract List<InsolvencyDate> apiToInsolvencyDateMapper(List<DatesApi> datesApis);
 
     @AfterMapping
-    protected void setCaseType(CaseApi caseApi, @MappingTarget InsolvencyCase insolvencyCase) {
+    protected void formatDate(DatesApi datesApi, @MappingTarget InsolvencyDate insolvencyDate) {
 
-        if (caseApi != null && caseApi.getType() != null) {
-            insolvencyCase.setType(retrieveApiEnumerationDescription
-                .getApiEnumerationDescription(CONSTANTS, INSOLVENCY_CASE_TYPE,
-                    caseApi.getType().getType(), getDebugMap(caseApi.getType().getType())));
+        if(datesApi != null && datesApi.getDate() != null) {
+            insolvencyDate.setDate(datesApi.getDate().format(getFormatter()));
         }
+    }
+
+    @AfterMapping
+    protected void setDateType(DatesApi datesApi, @MappingTarget InsolvencyDate insolvencyDate) {
+
+        if (datesApi != null && datesApi.getType() != null) {
+            insolvencyDate.setType(retrieveApiEnumerationDescription
+                .getApiEnumerationDescription(CONSTANTS, INSOLVENCY_CASE_DATE_TYPE,
+                    datesApi.getType().getType(), getDebugMap(datesApi.getType().name())));
+        }
+    }
+
+    private DateTimeFormatter getFormatter() {
+        return DateTimeFormatter.ofPattern(D_MMMM_UUUU);
     }
 
     private Map<String, String> getDebugMap(String debugString) {

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToInsolvencyMapper.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToInsolvencyMapper.java
@@ -1,0 +1,22 @@
+package uk.gov.companieshouse.document.generator.company.report.mapping.mappers.insolvency;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.springframework.web.context.annotation.RequestScope;
+import uk.gov.companieshouse.api.model.insolvency.InsolvencyApi;
+import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.Insolvency;
+
+@RequestScope
+@Mapper(componentModel = "spring", uses = {ApiToCaseMapper.class})
+public abstract class ApiToInsolvencyMapper {
+
+    public abstract Insolvency apiToInsolvencyMapper(InsolvencyApi insolvencyApi);
+
+    @AfterMapping
+    protected void calculateTotalNumberOfCases(InsolvencyApi insolvencyApi,
+        @MappingTarget Insolvency insolvency) {
+
+        insolvency.setTotalInsolvencyCases(insolvencyApi.getCases().size());
+    }
+}

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToInsolvencyMapper.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToInsolvencyMapper.java
@@ -17,6 +17,8 @@ public abstract class ApiToInsolvencyMapper {
     protected void calculateTotalNumberOfCases(InsolvencyApi insolvencyApi,
         @MappingTarget Insolvency insolvency) {
 
-        insolvency.setTotalInsolvencyCases(insolvencyApi.getCases().size());
+        if(insolvencyApi.getCases() != null) {
+            insolvency.setTotalInsolvencyCases(insolvencyApi.getCases().size());
+        }
     }
 }

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToPractitionerMapper.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToPractitionerMapper.java
@@ -1,18 +1,48 @@
 package uk.gov.companieshouse.document.generator.company.report.mapping.mappers.insolvency;
 
 
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Mappings;
 import org.springframework.web.context.annotation.RequestScope;
+import uk.gov.companieshouse.api.model.insolvency.DatesApi;
 import uk.gov.companieshouse.api.model.insolvency.PractitionerApi;
+import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items.InsolvencyDate;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items.Practitioner;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @RequestScope
 @Mapper(componentModel = "spring")
-public interface ApiToPractitionerMapper {
+public abstract class ApiToPractitionerMapper {
 
-    Practitioner apiToPractitionerMapper(PractitionerApi practitionerApi);
+    private static final String D_MMMM_UUUU = "d MMMM uuuu";
 
-    List<Practitioner> apiToPractitionerMapper(List<PractitionerApi> practitionerApi);
+    @Mappings({
+        @Mapping(target = "appointedOn", ignore = true),
+        @Mapping(target = "ceasedToActOn", ignore = true)
+    })
+    public abstract Practitioner apiToPractitionerMapper(PractitionerApi practitionerApi);
+
+    public abstract List<Practitioner> apiToPractitionerMapper(List<PractitionerApi> practitionerApi);
+
+
+    @AfterMapping
+    protected void formatDates(PractitionerApi practitionerApi, @MappingTarget Practitioner practitioner) {
+
+        if(practitionerApi != null && practitionerApi.getAppointedOn() != null) {
+            practitioner.setAppointedOn(practitionerApi.getAppointedOn().format(getFormatter()));
+        }
+
+        if(practitionerApi != null && practitionerApi.getCeasedToActOn() != null) {
+            practitioner.setCeasedToActOn(practitionerApi.getCeasedToActOn().format(getFormatter()));
+        }
+    }
+
+    private DateTimeFormatter getFormatter() {
+        return DateTimeFormatter.ofPattern(D_MMMM_UUUU);
+    }
 }

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToPractitionerMapper.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToPractitionerMapper.java
@@ -7,9 +7,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.Mappings;
 import org.springframework.web.context.annotation.RequestScope;
-import uk.gov.companieshouse.api.model.insolvency.DatesApi;
 import uk.gov.companieshouse.api.model.insolvency.PractitionerApi;
-import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items.InsolvencyDate;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items.Practitioner;
 
 import java.time.format.DateTimeFormatter;

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToPractitionerMapper.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToPractitionerMapper.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.document.generator.company.report.mapping.mappers.insolvency;
+
+
+import org.mapstruct.Mapper;
+import org.springframework.web.context.annotation.RequestScope;
+import uk.gov.companieshouse.api.model.insolvency.PractitionerApi;
+import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items.Practitioner;
+
+import java.util.List;
+
+@RequestScope
+@Mapper(componentModel = "spring")
+public interface ApiToPractitionerMapper {
+
+    Practitioner apiToPractitionerMapper(PractitionerApi practitionerApi);
+
+    List<Practitioner> apiToPractitionerMapper(List<PractitionerApi> practitionerApi);
+}

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/CompanyReportApiData.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/CompanyReportApiData.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.document.generator.company.report.mapping.model;
 
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.filinghistory.FilingHistoryApi;
+import uk.gov.companieshouse.api.model.insolvency.InsolvencyApi;
 import uk.gov.companieshouse.api.model.psc.PscsApi;
 import uk.gov.companieshouse.api.model.officers.OfficersApi;
 import uk.gov.companieshouse.api.model.statements.StatementsApi;
@@ -17,6 +18,8 @@ public class CompanyReportApiData {
     private FilingHistoryApi filingHistoryApi;
 
     private StatementsApi statementsApi;
+
+    private InsolvencyApi insolvencyApi;
 
     public CompanyProfileApi getCompanyProfileApi() {
         return companyProfileApi;
@@ -56,5 +59,13 @@ public class CompanyReportApiData {
 
     public void setStatementsApi(StatementsApi statementsApi) {
         this.statementsApi = statementsApi;
+    }
+
+    public InsolvencyApi getInsolvencyApi() {
+        return insolvencyApi;
+    }
+
+    public void setInsolvencyApi(InsolvencyApi insolvencyApi) {
+        this.insolvencyApi = insolvencyApi;
     }
 }

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/CompanyReport.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/CompanyReport.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.currentappointments.CurrentAppointments;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.foreigncompanydetails.ForeignCompanyDetails;
+import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.Insolvency;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.keyfilingdates.KeyFilingDates;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.previousnames.PreviousNames;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.pscs.Pscs;
@@ -49,6 +50,9 @@ public class CompanyReport {
 
     @JsonProperty("psc_statements")
     private Statements statements;
+
+    @JsonProperty("insolvency")
+    private Insolvency insolvency;
 
     public String getTimeStampCreated() {
         return TimeStampCreated;
@@ -120,5 +124,14 @@ public class CompanyReport {
 
     public void setStatements(Statements statements) {
         this.statements = statements;
+    }
+
+    public Insolvency getInsolvency() {
+        return insolvency;
+    }
+
+    public void setInsolvency(
+        Insolvency insolvency) {
+        this.insolvency = insolvency;
     }
 }

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/insolvency/Insolvency.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/insolvency/Insolvency.java
@@ -1,0 +1,32 @@
+package uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items.InsolvencyCase;
+
+import java.util.List;
+
+public class Insolvency {
+
+    @JsonProperty("total_insolvency_cases")
+    private Integer totalInsolvencyCases;
+
+    @JsonProperty("cases")
+    private List<InsolvencyCase> cases;
+
+    public Integer getTotalInsolvencyCases() {
+        return totalInsolvencyCases;
+    }
+
+    public void setTotalInsolvencyCases(Integer totalInsolvencyCases) {
+        this.totalInsolvencyCases = totalInsolvencyCases;
+    }
+
+    public List<InsolvencyCase> getCases() {
+        return cases;
+    }
+
+    public void setCases(
+        List<InsolvencyCase> cases) {
+        this.cases = cases;
+    }
+}

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/insolvency/items/InsolvencyCase.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/insolvency/items/InsolvencyCase.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class InsolvencyCase {
+
+    @JsonProperty("case_number")
+    private Long number;
+
+    @JsonProperty("case_type")
+    private String type;
+
+    @JsonProperty("practitioners")
+    private List<Practitioner> practitioners;
+
+    public Long getNumber() {
+        return number;
+    }
+
+    public void setNumber(Long number) {
+        this.number = number;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public List<Practitioner> getPractitioners() {
+        return practitioners;
+    }
+
+    public void setPractitioners(
+        List<Practitioner> practitioners) {
+        this.practitioners = practitioners;
+    }
+}

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/insolvency/items/InsolvencyCase.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/insolvency/items/InsolvencyCase.java
@@ -12,6 +12,9 @@ public class InsolvencyCase {
     @JsonProperty("case_type")
     private String type;
 
+    @JsonProperty("dates")
+    private List<InsolvencyDate> dates;
+
     @JsonProperty("practitioners")
     private List<Practitioner> practitioners;
 
@@ -31,12 +34,20 @@ public class InsolvencyCase {
         this.type = type;
     }
 
+    public List<InsolvencyDate> getDates() {
+        return dates;
+    }
+
+    public void setDates(
+        List<InsolvencyDate> dates) {
+        this.dates = dates;
+    }
+
     public List<Practitioner> getPractitioners() {
         return practitioners;
     }
 
-    public void setPractitioners(
-        List<Practitioner> practitioners) {
+    public void setPractitioners(List<Practitioner> practitioners) {
         this.practitioners = practitioners;
     }
 }

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/insolvency/items/InsolvencyDate.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/insolvency/items/InsolvencyDate.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class InsolvencyDate {
+
+    @JsonProperty("date")
+    private String date;
+
+    @JsonProperty("type")
+    private String type;
+
+    public String getDate() {
+        return date;
+    }
+
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/insolvency/items/Practitioner.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/insolvency/items/Practitioner.java
@@ -3,8 +3,6 @@ package uk.gov.companieshouse.document.generator.company.report.mapping.model.do
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.common.Address;
 
-import java.time.LocalDate;
-
 public class Practitioner {
 
     @JsonProperty("name")
@@ -14,10 +12,10 @@ public class Practitioner {
     private Address address;
 
     @JsonProperty("appointed_on")
-    private LocalDate appointedOn;
+    private String appointedOn;
 
     @JsonProperty("ceased_to_act_on")
-    private LocalDate ceasedToActOn;
+    private String ceasedToActOn;
 
     public String getName() {
         return name;
@@ -36,19 +34,19 @@ public class Practitioner {
         this.address = address;
     }
 
-    public LocalDate getAppointedOn() {
+    public String getAppointedOn() {
         return appointedOn;
     }
 
-    public void setAppointedOn(LocalDate appointedOn) {
+    public void setAppointedOn(String appointedOn) {
         this.appointedOn = appointedOn;
     }
 
-    public LocalDate getCeasedToActOn() {
+    public String getCeasedToActOn() {
         return ceasedToActOn;
     }
 
-    public void setCeasedToActOn(LocalDate ceasedToActOn) {
+    public void setCeasedToActOn(String ceasedToActOn) {
         this.ceasedToActOn = ceasedToActOn;
     }
 }

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/insolvency/items/Practitioner.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/insolvency/items/Practitioner.java
@@ -1,0 +1,54 @@
+package uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.common.Address;
+
+import java.time.LocalDate;
+
+public class Practitioner {
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("address")
+    private Address address;
+
+    @JsonProperty("appointed_on")
+    private LocalDate appointedOn;
+
+    @JsonProperty("ceased_to_act_on")
+    private LocalDate ceasedToActOn;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(
+        Address address) {
+        this.address = address;
+    }
+
+    public LocalDate getAppointedOn() {
+        return appointedOn;
+    }
+
+    public void setAppointedOn(LocalDate appointedOn) {
+        this.appointedOn = appointedOn;
+    }
+
+    public LocalDate getCeasedToActOn() {
+        return ceasedToActOn;
+    }
+
+    public void setCeasedToActOn(LocalDate ceasedToActOn) {
+        this.ceasedToActOn = ceasedToActOn;
+    }
+}

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/CompanyReportApiClientService.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/CompanyReportApiClientService.java
@@ -22,6 +22,7 @@ public class CompanyReportApiClientService {
     private static final String X_REQUEST_ID_HEADER = "x-request-id";
 
     public ApiClient getApiClient() {
+
         HttpClient httpClient = new ApiKeyHttpClient(chsApiKey);
 
         setRequestId(httpClient);
@@ -39,8 +40,10 @@ public class CompanyReportApiClientService {
      * @param httpClient
      */
     private static void setRequestId(HttpClient httpClient) {
+
         ServletRequestAttributes attr = (ServletRequestAttributes) RequestContextHolder
             .currentRequestAttributes();
+
         HttpServletRequest request = attr.getRequest();
 
         String requestId = (String) request.getAttribute(X_REQUEST_ID_HEADER);

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/CompanyService.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/CompanyService.java
@@ -12,8 +12,12 @@ import uk.gov.companieshouse.document.generator.company.report.exception.Service
 @Service
 public class CompanyService {
 
-    @Autowired
     private CompanyReportApiClientService companyReportApiClientService;
+
+    @Autowired
+    public CompanyService(CompanyReportApiClientService companyReportApiClientService) {
+        this.companyReportApiClientService = companyReportApiClientService;
+    }
 
     private static final UriTemplate GET_COMPANY_URI =
         new UriTemplate("/company/{companyNumber}");

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/InsolvencyService.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/InsolvencyService.java
@@ -12,8 +12,12 @@ import uk.gov.companieshouse.document.generator.company.report.exception.Service
 @Service
 public class InsolvencyService {
 
-    @Autowired
     private CompanyReportApiClientService companyReportApiClientService;
+
+    @Autowired
+    public InsolvencyService(CompanyReportApiClientService companyReportApiClientService) {
+        this.companyReportApiClientService = companyReportApiClientService;
+    }
 
     private static final UriTemplate GET_INSOLVENCY_URI =
         new UriTemplate("/company/{companyNumber}/insolvency");

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/InsolvencyService.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/InsolvencyService.java
@@ -1,0 +1,40 @@
+package uk.gov.companieshouse.document.generator.company.report.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriTemplate;
+import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.insolvency.InsolvencyApi;
+import uk.gov.companieshouse.document.generator.company.report.exception.ServiceException;
+
+@Service
+public class InsolvencyService {
+
+    @Autowired
+    private CompanyReportApiClientService companyReportApiClientService;
+
+    private static final UriTemplate GET_INSOLVENCY_URI =
+        new UriTemplate("/company/{companyNumber}/insolvency");
+
+    public InsolvencyApi getInsolvency(String companyNumber) throws ServiceException {
+
+        InsolvencyApi insolvencyApi;
+
+        ApiClient apiClient = companyReportApiClientService.getApiClient();
+
+        String uri = GET_INSOLVENCY_URI.expand(companyNumber).toString();
+
+        try {
+            insolvencyApi =  apiClient.insolvency().get(uri).execute().getData();
+        } catch (ApiErrorResponseException e) {
+
+            throw new ServiceException("Error retrieving insolvency", e);
+        } catch (URIValidationException e) {
+
+            throw new ServiceException("Invalid URI for insolvency resource", e);
+        }
+        return insolvencyApi;
+    }
+}

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/OfficerService.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/OfficerService.java
@@ -13,8 +13,12 @@ import uk.gov.companieshouse.document.generator.company.report.exception.Service
 @Service
 public class OfficerService {
 
-    @Autowired
     private CompanyReportApiClientService companyReportApiClientService;
+
+    @Autowired
+    public OfficerService(CompanyReportApiClientService companyReportApiClientService) {
+        this.companyReportApiClientService = companyReportApiClientService;
+    }
 
     private static final UriTemplate GET_OFFICERS_URI =
         new UriTemplate("/company/{companyNumber}/officers");

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/PscsService.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/PscsService.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.document.generator.company.report.service;
 
-import javax.sql.rowset.serial.SerialException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriTemplate;
@@ -8,15 +7,18 @@ import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.handler.psc.request.PscsList;
-import uk.gov.companieshouse.api.model.psc.PscApi;
 import uk.gov.companieshouse.api.model.psc.PscsApi;
 import uk.gov.companieshouse.document.generator.company.report.exception.ServiceException;
 
 @Service
 public class PscsService {
 
-    @Autowired
     private CompanyReportApiClientService companyReportApiClientService;
+
+    @Autowired
+    public PscsService(CompanyReportApiClientService companyReportApiClientService) {
+        this.companyReportApiClientService = companyReportApiClientService;
+    }
 
     private static final UriTemplate GET_PSCS_URI =
             new UriTemplate("/company/{companyNumber}/persons-with-significant-control");

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/RecentFilingHistoryService.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/RecentFilingHistoryService.java
@@ -13,13 +13,17 @@ import uk.gov.companieshouse.document.generator.company.report.exception.Service
 @Service
 public class RecentFilingHistoryService {
 
-    @Autowired
     private CompanyReportApiClientService companyReportApiClientService;
+
+    @Autowired
+    public RecentFilingHistoryService(CompanyReportApiClientService companyReportApiClientService) {
+        this.companyReportApiClientService = companyReportApiClientService;
+    }
 
     private static final UriTemplate GET_RECENT_FILING_HISTORY_URI =
         new UriTemplate("/company/{company_number}/filing-history");
 
-    public FilingHistoryApi getFilingHistory(String companyNumber) throws ServiceException, ApiErrorResponseException, URIValidationException {
+    public FilingHistoryApi getFilingHistory(String companyNumber) throws ServiceException {
 
         FilingHistoryApi filingHistoryApi;
 

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/StatementsService.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/service/StatementsService.java
@@ -13,8 +13,12 @@ import uk.gov.companieshouse.document.generator.company.report.exception.Service
 @Service
 public class StatementsService {
 
-    @Autowired
     private CompanyReportApiClientService companyReportApiClientService;
+
+    @Autowired
+    public StatementsService(CompanyReportApiClientService companyReportApiClientService) {
+        this.companyReportApiClientService = companyReportApiClientService;
+    }
 
     private static final UriTemplate GET_STATEMENTS_URI =
             new UriTemplate("/company/{companyNumber}/persons-with-significant-control-statements");

--- a/document-generator-company-report/src/test/java/uk/gov/companieshouse/document/generator/company/report/handler/CompanyReportDataHandlerTest.java
+++ b/document-generator-company-report/src/test/java/uk/gov/companieshouse/document/generator/company/report/handler/CompanyReportDataHandlerTest.java
@@ -15,6 +15,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.filinghistory.FilingApi;
 import uk.gov.companieshouse.api.model.filinghistory.FilingHistoryApi;
+import uk.gov.companieshouse.api.model.insolvency.CaseApi;
+import uk.gov.companieshouse.api.model.insolvency.CaseTypeApi;
+import uk.gov.companieshouse.api.model.insolvency.DatesApi;
+import uk.gov.companieshouse.api.model.insolvency.InsolvencyApi;
+import uk.gov.companieshouse.api.model.insolvency.PractitionerApi;
 import uk.gov.companieshouse.api.model.officers.OfficersApi;
 import uk.gov.companieshouse.api.model.psc.PscsApi;
 import uk.gov.companieshouse.api.model.statements.StatementApi;
@@ -22,7 +27,9 @@ import uk.gov.companieshouse.api.model.statements.StatementsApi;
 import uk.gov.companieshouse.document.generator.company.report.mapping.mappers.CompanyReportMapper;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.CompanyReportApiData;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.CompanyReport;
+import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items.Practitioner;
 import uk.gov.companieshouse.document.generator.company.report.service.CompanyService;
+import uk.gov.companieshouse.document.generator.company.report.service.InsolvencyService;
 import uk.gov.companieshouse.document.generator.company.report.service.OfficerService;
 import uk.gov.companieshouse.document.generator.company.report.service.PscsService;
 import uk.gov.companieshouse.document.generator.company.report.service.RecentFilingHistoryService;
@@ -66,6 +73,9 @@ public class CompanyReportDataHandlerTest {
     @Mock
     private RecentFilingHistoryService mockRecentFilingHistoryService;
 
+    @Mock
+    private InsolvencyService mockInsolvencyService;
+
     @InjectMocks
     private CompanyReportDataHandler companyReportDataHandler;
 
@@ -82,6 +92,7 @@ public class CompanyReportDataHandlerTest {
         OfficersApi officersApi = createOfficers();
         FilingHistoryApi filingHistoryApi = createFilingHistory();
         StatementsApi statementsApi = createStatementsApi();
+        InsolvencyApi insolvencyApi = createInsolvencyApi();
 
         CompanyReportApiData companyReportApiData = new CompanyReportApiData();
         companyReportApiData.setCompanyProfileApi(companyProfileApi);
@@ -92,6 +103,7 @@ public class CompanyReportDataHandlerTest {
         when(mockRecentFilingHistoryService.getFilingHistory(any(String.class))).thenReturn(filingHistoryApi);
         when(mockCompanyReportMapper.mapCompanyReport(any(CompanyReportApiData.class), anyString(), anyString())).thenReturn(new CompanyReport());
         when(mockStatementsService.getStatements(any(String.class))).thenReturn(statementsApi);
+        when(mockInsolvencyService.getInsolvency(anyString())).thenReturn(insolvencyApi);
 
         DocumentInfoResponse documentInfoResponse = companyReportDataHandler.getCompanyReport(RESOURCE_URI, REQUEST_ID);
 
@@ -137,6 +149,7 @@ public class CompanyReportDataHandlerTest {
         links.put("officers", "/officers");
         links.put("filing_history", "/filing-history");
         links.put("persons_with_significant_control_statements", "/persons_with_significant_control_statements");
+        links.put("insolvency", "/insolvency");
 
         companyProfileApi.setLinks(links);
 
@@ -179,5 +192,22 @@ public class CompanyReportDataHandlerTest {
         statementsApi.setItems(statementApiList);
 
         return statementsApi;
+    }
+
+    private InsolvencyApi createInsolvencyApi() {
+
+        InsolvencyApi insolvencyApi = new InsolvencyApi();
+
+        List<CaseApi> caseApiList = new ArrayList<>();
+        CaseApi caseApi = new CaseApi();
+        caseApi.setPractitioners(new ArrayList<>());
+        caseApi.setDates(new ArrayList<>());
+        caseApi.setNumber(1L);
+        caseApi.setType(CaseTypeApi.ADMINISTRATION_ORDER);
+
+        caseApiList.add(caseApi);
+        insolvencyApi.setCases(caseApiList);
+
+        return insolvencyApi;
     }
 }

--- a/document-generator-company-report/src/test/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToCaseMapperTest.java
+++ b/document-generator-company-report/src/test/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToCaseMapperTest.java
@@ -1,0 +1,74 @@
+package uk.gov.companieshouse.document.generator.company.report.mapping.mappers.insolvency;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.insolvency.CaseApi;
+import uk.gov.companieshouse.api.model.insolvency.CaseTypeApi;
+import uk.gov.companieshouse.document.generator.common.descriptions.RetrieveApiEnumerationDescription;
+import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items.InsolvencyCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ApiToCaseMapperTest {
+
+    @Mock
+    private ApiToPractitionerMapper mockApiToPractitionerMapper;
+
+    @Mock
+    private ApiToInsolvencyDateMapper mockApiToInsolvencyDateMapper;
+
+    @Mock
+    private RetrieveApiEnumerationDescription mockRetrieveApiEnumerationDescription;
+
+    @InjectMocks
+    private ApiToCaseMapper apiToCaseMapper = new ApiToCaseMapperImpl();
+
+    private String ENUMERATION_DESCRIPTION = "enumeration-description";
+
+    @Test
+    @DisplayName("tests case api data maps to case model")
+    void testApiToCaseMaps() {
+
+        when(mockApiToInsolvencyDateMapper.apiToInsolvencyDateMapper(anyList())).thenReturn(new ArrayList<>());
+        when(mockApiToPractitionerMapper.apiToPractitionerMapper(anyList())).thenReturn(new ArrayList<>());
+        when(mockRetrieveApiEnumerationDescription
+            .getApiEnumerationDescription(anyString(), anyString(), anyString(), anyMap()))
+            .thenReturn(ENUMERATION_DESCRIPTION);
+
+        List<InsolvencyCase> insolvencyCase = apiToCaseMapper.apiToCaseMapper(createCasesApi());
+
+        assertNotNull(insolvencyCase);
+        assertNotNull(insolvencyCase.get(0).getDates());
+        assertNotNull(insolvencyCase.get(0).getPractitioners());
+        assertEquals(insolvencyCase.get(0).getType(), ENUMERATION_DESCRIPTION);
+    }
+
+    private List<CaseApi> createCasesApi() {
+
+        List<CaseApi> caseApiList = new ArrayList<>();
+        CaseApi caseApi = new CaseApi();
+        caseApi.setNumber(1L);
+        caseApi.setType(CaseTypeApi.ADMINISTRATION_ORDER);
+        caseApi.setDates(new ArrayList<>());
+        caseApi.setPractitioners(new ArrayList<>());
+
+        caseApiList.add(caseApi);
+
+        return caseApiList;
+    }
+}

--- a/document-generator-company-report/src/test/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToInsolvencyDateMapperTest.java
+++ b/document-generator-company-report/src/test/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToInsolvencyDateMapperTest.java
@@ -1,0 +1,65 @@
+package uk.gov.companieshouse.document.generator.company.report.mapping.mappers.insolvency;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.insolvency.DatesApi;
+import uk.gov.companieshouse.api.model.insolvency.DatesTypeApi;
+import uk.gov.companieshouse.document.generator.common.descriptions.RetrieveApiEnumerationDescription;
+import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items.InsolvencyDate;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ApiToInsolvencyDateMapperTest {
+
+    @Mock
+    private RetrieveApiEnumerationDescription mockRetrieveApiEnumerationDescription;
+
+    @InjectMocks
+    private ApiToInsolvencyDateMapper apiToInsolvencyDateMapper = new ApiToInsolvencyDateMapperImpl();
+
+    private LocalDate TEST_DATE = LocalDate.of(2019,01,01);
+    private String FORMATTED_DATE = "1 January 2019";
+    private String ENUMERATION_DESCRIPTION = "enumeration-description";
+
+    @Test
+    @DisplayName("tests dates api data maps to dates model")
+    void testApiToDatesMaps() {
+
+        when(mockRetrieveApiEnumerationDescription
+            .getApiEnumerationDescription(anyString(), anyString(), anyString(), anyMap()))
+            .thenReturn(ENUMERATION_DESCRIPTION);
+
+        List<InsolvencyDate> insolvencyDates = apiToInsolvencyDateMapper.apiToInsolvencyDateMapper(createDatesApi());
+
+        assertNotNull(insolvencyDates);
+        assertEquals(insolvencyDates.get(0).getDate(), FORMATTED_DATE);
+        assertEquals(insolvencyDates.get(0).getType(), ENUMERATION_DESCRIPTION);
+
+    }
+
+    private List<DatesApi> createDatesApi() {
+
+        List<DatesApi> datesApiList = new ArrayList<>();
+        DatesApi datesApi = new DatesApi();
+        datesApi.setDate(TEST_DATE);
+        datesApi.setType(DatesTypeApi.ADMINISTRATION_DISCHARGED_ON);
+        datesApiList.add(datesApi);
+
+        return datesApiList;
+    }
+}

--- a/document-generator-company-report/src/test/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToInsolvencyMapperTest.java
+++ b/document-generator-company-report/src/test/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToInsolvencyMapperTest.java
@@ -1,0 +1,72 @@
+package uk.gov.companieshouse.document.generator.company.report.mapping.mappers.insolvency;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.insolvency.CaseApi;
+import uk.gov.companieshouse.api.model.insolvency.CaseTypeApi;
+import uk.gov.companieshouse.api.model.insolvency.InsolvencyApi;
+import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.Insolvency;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ApiToInsolvencyMapperTest {
+
+    @Mock
+    private ApiToCaseMapper mockApiToCaseMapper;
+
+    @InjectMocks
+    private ApiToInsolvencyMapper apiToInsolvencyMapper = new ApiToInsolvencyMapperImpl();
+
+    @Test
+    @DisplayName("tests Insolvency api data maps to Insolvency model")
+    void testApiToInsolvencyMaps() {
+
+
+        when(mockApiToCaseMapper.apiToCaseMapper(anyList())).thenReturn(new ArrayList<>());
+        Insolvency insolvency = apiToInsolvencyMapper.apiToInsolvencyMapper(createInsolvencyApi());
+
+        assertNotNull(insolvency);
+        assertEquals(insolvency.getTotalInsolvencyCases(), Integer.valueOf(2));
+    }
+
+    private InsolvencyApi createInsolvencyApi() {
+
+        InsolvencyApi insolvencyApi = new InsolvencyApi();
+        insolvencyApi.setCases(createCases());
+        insolvencyApi.setStatus(new ArrayList<>());
+
+        return insolvencyApi;
+    }
+
+    private List<CaseApi> createCases() {
+
+        List<CaseApi> caseApiList = new ArrayList<>();
+        Long number = 0L;
+
+        for(int i = 0; i < 2; i++) {
+
+            CaseApi caseApi = new CaseApi();
+            caseApi.setNumber(++number);
+            caseApi.setPractitioners(new ArrayList<>());
+            caseApi.setDates(new ArrayList<>());
+            caseApi.setType(CaseTypeApi.ADMINISTRATION_ORDER);
+
+            caseApiList.add(caseApi);
+        }
+
+        return caseApiList;
+    }
+}

--- a/document-generator-company-report/src/test/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToPractitionerMapperTest.java
+++ b/document-generator-company-report/src/test/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/insolvency/ApiToPractitionerMapperTest.java
@@ -1,0 +1,90 @@
+package uk.gov.companieshouse.document.generator.company.report.mapping.mappers.insolvency;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.common.Address;
+import uk.gov.companieshouse.api.model.insolvency.PractitionerApi;
+import uk.gov.companieshouse.api.model.insolvency.RoleApi;
+import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.insolvency.items.Practitioner;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith({MockitoExtension.class})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ApiToPractitionerMapperTest {
+
+    @InjectMocks
+    private ApiToPractitionerMapper apiToPractitionerMapper = new ApiToPractitionerMapperImpl();
+
+    private String NAME = "test name";
+    private LocalDate DATE = LocalDate.of(2019,01,01);
+    private String FORMATTED_DATE = "1 January 2019";
+    private String ADDRESS_LINE_ONE = "address line one";
+    private String ADDRESS_LINE_TWO = "address line two";
+    private String CARE_OF = "care of";
+    private String COUNTRY = "country";
+    private String LOCALITY = "locality";
+    private String PO_BOX = "po box";
+    private String POSTAL_CODE = "postal code";
+    private String PREMISES = "premises";
+    private String REGION = "region";
+
+    @Test
+    @DisplayName("tests practitioner api data maps to practitioner model")
+    void testApiToPractitionerMaps() {
+
+        List<Practitioner> practitioners = apiToPractitionerMapper.apiToPractitionerMapper(createPractitionerApi());
+
+        assertNotNull(practitioners);
+        assertEquals(practitioners.get(0).getName(), NAME);
+        assertEquals(practitioners.get(0).getAppointedOn(), FORMATTED_DATE);
+        assertEquals(practitioners.get(0).getCeasedToActOn(), FORMATTED_DATE);
+        assertEquals(practitioners.get(0).getAddress().getAddressLine1(), ADDRESS_LINE_ONE);
+        assertEquals(practitioners.get(0).getAddress().getAddressLine2(), ADDRESS_LINE_TWO);
+        assertEquals(practitioners.get(0).getAddress().getCareOf(), CARE_OF);
+        assertEquals(practitioners.get(0).getAddress().getCountry(), COUNTRY);
+        assertEquals(practitioners.get(0).getAddress().getLocality(), LOCALITY);
+        assertEquals(practitioners.get(0).getAddress().getPoBox(), PO_BOX);
+        assertEquals(practitioners.get(0).getAddress().getPostalCode(), POSTAL_CODE);
+        assertEquals(practitioners.get(0).getAddress().getPremises(), PREMISES);
+        assertEquals(practitioners.get(0).getAddress().getRegion(), REGION);
+    }
+
+    private List<PractitionerApi> createPractitionerApi() {
+
+        List<PractitionerApi> practitionerApiList = new ArrayList<>();
+        PractitionerApi practitionerApi = new PractitionerApi();
+
+        practitionerApi.setName(NAME);
+        practitionerApi.setCeasedToActOn(DATE);
+        practitionerApi.setAppointedOn(DATE);
+
+        Address address = new Address();
+        address.setAddressLine1(ADDRESS_LINE_ONE);
+        address.setAddressLine2(ADDRESS_LINE_TWO);
+        address.setCareOf(CARE_OF);
+        address.setCountry(COUNTRY);
+        address.setLocality(LOCALITY);
+        address.setPoBox(PO_BOX);
+        address.setPostalCode(POSTAL_CODE);
+        address.setPremises(PREMISES);
+        address.setRegion(REGION);
+
+        practitionerApi.setAddress(address);
+
+        practitionerApiList.add(practitionerApi);
+
+        return practitionerApiList;
+    }
+
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
         <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
 
-        <api-sdk-java.version>4.1.24</api-sdk-java.version>
+        <api-sdk-java.version>4.1.28</api-sdk-java.version>
 
         <gson.version>2.8.0</gson.version>
 


### PR DESCRIPTION
Mapping of insolvency api to allow insolvency to be added to company report document.

- Added Mappers for insolvency Api
- Added models to company report for insolvency
- Updated dataHandler to call Insolvency Api
- Added service to control the insolvency api call
- Added Junit tests

Resolves PCI 59