### PR TITLE
Add required CSS for the Company Report to fix IOS issues

### DIFF
--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -56,6 +56,18 @@
         text-transform: none;
       }
 
+      .heading-medium {
+        font-size: 24px;
+        font-weight: 700;
+        line-height: 1.25;
+      }
+
+      @media (min-width: 641px)
+      .heading-medium {
+        margin-top: 1.875em;
+        margin-bottom: 0.83333em;
+      }
+
       .heading-small {
         font-family: "proxima_nova", Arial, sans-serif;
         font-weight: 700;
@@ -65,6 +77,7 @@
       li {
         display: list-item;
         text-align: -webkit-match-parent;
+        font-size: 16px;
        }
 
       .list li {
@@ -118,14 +131,48 @@
         text-transform: none;
       }
 
+      table {
+        border-collapse: collapse;
+        border-spacing: 0;
+        width: 100%;
+      }
+
+      @media (min-width: 641px) {
+      table th, table td {
+        font-size: 19px;
+        line-height: 1.31579;
+        }
+      }
+
+      table th, table td {
+        font-family: "proxima_nova", Arial, sans-serif;
+        font-weight: 400;
+        text-transform: none;
+        padding: 0.63158em 1.05263em 0.47368em 0;
+        text-align: left;
+        color: #0b0c0c;
+        border-bottom: 1px solid #bfc1c3;
+      }
+
+       table th {
+        font-weight: 700;
+      }
+
       .grid-row {
         margin: 0 -15px;
       }
 
-      .column-quarter {
-        float: left;
-        width: 25%;
-      }
+      @media (min-width: 641px) {
+        .column-quarter {
+           float: left;
+           width: 25%;
+         }
+       }
+
+        .column-quarter {
+          padding: 0 15px;
+          box-sizing: border-box;
+        }
 
       .column-half {
         float: left;

--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -26,11 +26,20 @@
         font-family: "proxima_nova", Arial, sans-serif;
       }
 
+      body {
+        margin: 0 30px;
+      }
+
+      #page-container {
+        max-width: 960px;
+      }
+
       h1.heading-xlarge {
         word-wrap: break-word;
         font: 48px proxima_nova, Arial, sans-serif;
         font-weight: 700;
         text-transform: none;
+        margin: 30px 0 60px;
       }
 
       .heading-small {

--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -38,6 +38,20 @@
         }
       }
 
+     main {
+        padding-bottom: 3em;
+        font-family: "proxima_nova", Arial, sans-serif;
+        font-weight: 400;
+        text-transform: none;
+      }
+
+      @media (min-width: 641px) {
+      main {
+        font-size: 19px;
+        line-height: 1.31579;
+        }
+      }
+
       h1.heading-xlarge {
         word-wrap: break-word;
         font: 48px proxima_nova, Arial, sans-serif;
@@ -46,13 +60,6 @@
         margin: 30px 0 60px;
       }
 
-        @media (min-width: 641px) {
-          .heading-large {
-            font-size: 36px;
-            line-height: 1.11111;
-          }
-        }
-
       .heading-large {
         margin-bottom: 1em;
         font-family: "proxima_nova", Arial, sans-serif;
@@ -60,37 +67,50 @@
         text-transform: none;
       }
 
+       @media (min-width: 641px) {
+         .heading-large {
+           font-size: 36px;
+           line-height: 1.11111;
+         }
+       }
+
       .heading-medium {
         font-size: 24px;
         font-weight: 700;
         line-height: 1.25;
       }
 
-      @media (min-width: 641px)
-      .heading-medium {
-        margin-top: 1.875em;
-        margin-bottom: 0.83333em;
-      }
+      @media (min-width: 641px) {
+          .heading-medium {
+            margin-top: 1.875em;
+            margin-bottom: 0.83333em;
+          }
+       }
 
       .heading-small {
         font-family: "proxima_nova", Arial, sans-serif;
         font-weight: 700;
         text-transform: none;
+        margin-bottom: 0.3125em
       }
 
-      li {
-        display: list-item;
-        text-align: -webkit-match-parent;
-        font-size: 16px;
-       }
+       @media (min-width: 641px) {
+         .heading-small {
+           margin-top: 1.05263em;
+           font-size: 19px;
+           line-height: 1.31579;
+           }
+        }
 
-      .list li {
-        margin-bottom: 5px;
+     .list {
+        padding: 0;
+        margin-top: 5px;
+        margin-bottom: 20px;
       }
 
-      ul.list.list-bullet {
-        margin: 5px 0px 20px;
-        padding: 0px 0px 0px 20px;
+      .list-bullet {
+       list-style-type: disc;
+       padding-left: 20px;
       }
 
       .visually-hidden {
@@ -122,19 +142,6 @@
         background-color: #4B5253;
       }
 
-      @media (min-width: 641px)
-      main {
-        font-size: 19px;
-        line-height: 1.31579;
-      }
-
-      main {
-        padding-bottom: 3em;
-        font-family: "proxima_nova", Arial, sans-serif;
-        font-weight: 400;
-        text-transform: none;
-      }
-
       table {
         border-collapse: collapse;
         border-spacing: 0;
@@ -149,7 +156,7 @@
         font-family: "proxima_nova", Arial, sans-serif;
         font-weight: 400;
         text-transform: none;
-        padding: 0.63158em 1.05263em 0.47368em 0;
+        padding: 0.6em 1em 1em 0;
         text-align: left;
         color: #0b0c0c;
         border-bottom: 1px solid #bfc1c3;

--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -21,6 +21,35 @@
     <title>{{$companyRegistrationInformation.company_name}}</title>
     <style type="text/css">
 
+      html {
+        -webkit-font-smoothing: antialiased;
+        font-family: "proxima_nova", Arial, sans-serif;
+      }
+
+      h1.heading-xlarge {
+        word-wrap: break-word;
+        font: 48px proxima_nova, Arial, sans-serif;
+        font-weight: 700;
+        text-transform: none;
+      }
+
+      .heading-small {
+        font-family: "proxima_nova", Arial, sans-serif;
+        font-weight: 700;
+        text-transform: none;
+      }
+
+      .visually-hidden {
+        position: absolute;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        height: 1px;
+        width: 1px;
+        margin: -1px;
+        padding: 0;
+        border: 0;
+      }
+
       main {
         padding-bottom: 3em;
       }
@@ -123,8 +152,6 @@
           }
         }
     </style>
-    <link href="https://d11ystzvnk2sve.cloudfront.net/stylesheets/assets-digital-cabinet-office-gov-uk-static/govuk-template.css" media="screen" rel="stylesheet" type="text/css">
-    <link href="https://d11ystzvnk2sve.cloudfront.net/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css">
 </head>
 <body id="page-container">
 

--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -278,8 +278,8 @@
           }
         }
     </style>
-    <!--<link href="https://d11ystzvnk2sve.cloudfront.net/stylesheets/assets-digital-cabinet-office-gov-uk-static/govuk-template.css" media="screen" rel="stylesheet" type="text/css">-->
-    <!--<link href="https://d11ystzvnk2sve.cloudfront.net/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css">-->
+    <link href="https://d11ystzvnk2sve.cloudfront.net/stylesheets/assets-digital-cabinet-office-gov-uk-static/govuk-template.css" media="screen" rel="stylesheet" type="text/css">
+    <link href="https://d11ystzvnk2sve.cloudfront.net/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css">
 </head>
 <body id="page-container">
 

--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -21,17 +21,21 @@
     <title>{{$companyRegistrationInformation.company_name}}</title>
     <style type="text/css">
 
-      html {
-        -webkit-font-smoothing: antialiased;
-        font-family: "proxima_nova", Arial, sans-serif;
-      }
-
-      body {
-        margin: 0 30px;
-      }
-
       #page-container {
         max-width: 960px;
+        margin: 0 15px;
+      }
+
+      @media (min-width: 641px) {
+        #page-container {
+            margin: 0 30px;
+         }
+       }
+
+       @media (min-width: 1020px) {
+        #page-container {
+          margin: 0 auto;
+        }
       }
 
       h1.heading-xlarge {
@@ -137,11 +141,8 @@
         width: 100%;
       }
 
-      @media (min-width: 641px) {
-      table th, table td {
-        font-size: 19px;
-        line-height: 1.31579;
-        }
+      table tr td {
+        vertical-align: text-top;
       }
 
       table th, table td {
@@ -152,6 +153,13 @@
         text-align: left;
         color: #0b0c0c;
         border-bottom: 1px solid #bfc1c3;
+      }
+
+      @media (min-width: 641px) {
+      table th, table td {
+        font-size: 19px;
+        line-height: 1.31579;
+        }
       }
 
        table th {

--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -42,10 +42,38 @@
         margin: 30px 0 60px;
       }
 
+        @media (min-width: 641px) {
+          .heading-large {
+            font-size: 36px;
+            line-height: 1.11111;
+          }
+        }
+
+      .heading-large {
+        margin-bottom: 1em;
+        font-family: "proxima_nova", Arial, sans-serif;
+        font-weight: 700;
+        text-transform: none;
+      }
+
       .heading-small {
         font-family: "proxima_nova", Arial, sans-serif;
         font-weight: 700;
         text-transform: none;
+      }
+
+      li {
+        display: list-item;
+        text-align: -webkit-match-parent;
+       }
+
+      .list li {
+        margin-bottom: 5px;
+      }
+
+      ul.list.list-bullet {
+        margin: 5px 0px 20px;
+        padding: 0px 0px 0px 20px;
       }
 
       .visually-hidden {
@@ -59,8 +87,35 @@
         border: 0;
       }
 
+      span.status-tag {
+        background-color: #006435;
+        color: #fff;
+        margin-left: 0.75em;
+        vertical-align: baseline;
+        padding: 2px 5px 1px;
+        font-weight: 700;
+        font-size: 14px;
+        text-transform: uppercase;
+        display: inline-block;
+        position: relative;
+        top: -0.05em;
+      }
+
+      span.status-tag.ceased-tag {
+        background-color: #4B5253;
+      }
+
+      @media (min-width: 641px)
+      main {
+        font-size: 19px;
+        line-height: 1.31579;
+      }
+
       main {
         padding-bottom: 3em;
+        font-family: "proxima_nova", Arial, sans-serif;
+        font-weight: 400;
+        text-transform: none;
       }
 
       .grid-row {
@@ -161,6 +216,8 @@
           }
         }
     </style>
+    <!--<link href="https://d11ystzvnk2sve.cloudfront.net/stylesheets/assets-digital-cabinet-office-gov-uk-static/govuk-template.css" media="screen" rel="stylesheet" type="text/css">-->
+    <!--<link href="https://d11ystzvnk2sve.cloudfront.net/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css">-->
 </head>
 <body id="page-container">
 


### PR DESCRIPTION
IOS browsers before version 13 fail to load URL resources such as stylesheets when the Content-Disposition: attachment header is present. To fix this the required CSS is extracted into the document.

Resolves: PCI-250