### PR TITLE
Add type to Charge model

### DIFF
--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/mortgagechargedetails/ApiToChargesMapper.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/mortgagechargedetails/ApiToChargesMapper.java
@@ -32,6 +32,7 @@ public abstract class ApiToChargesMapper {
 
     @Mappings({
         @Mapping(source = "classification.type", target = "type"),
+        @Mapping(source = "classification.description", target = "classificationDescription"),
         @Mapping(source = "createdOn", target = "created", dateFormat = D_MMMM_UUUU),
         @Mapping(source = "deliveredOn", target = "delivered", dateFormat = D_MMMM_UUUU),
         @Mapping(source = "satisfiedOn", target = "satisfiedOn", dateFormat = D_MMMM_UUUU),

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/mortgagechargedetails/items/Charge.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/mortgagechargedetails/items/Charge.java
@@ -12,6 +12,9 @@ public class Charge {
     @JsonProperty("type")
     private String type;
 
+    @JsonProperty("classification_description")
+    private String classificationDescription;
+
     @JsonProperty("created")
     private String created;
 
@@ -128,5 +131,13 @@ public class Charge {
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    public String getClassificationDescription() {
+        return classificationDescription;
+    }
+
+    public void setClassificationDescription(String classificationDescription) {
+        this.classificationDescription = classificationDescription;
     }
 }

--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -825,7 +825,9 @@
                 {{if eq .type "NATURE_OF_CHARGE"}}
                 <div>
                     <p class="data">Nature of charge<br>
-                        <span class="normal">{{.charge_description}}</span>
+                        {{if .classification_description}}
+                            <span class="normal">{{.classification_description}}</span>
+                        {{end}}
                 </div>
                 {{end}}
 


### PR DESCRIPTION
Updated logic in mapper to set description dependent on charge code field and not aquired on field
Update company report template to output additional section when type field is nature of charge

Resolves: PCI-237