### PR TITLE
Set director index when not present in order to fix template render issue

### DIFF
--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
@@ -576,6 +576,7 @@ public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMap
                         loan.setDirectorIndex(directorIndexes.get(loan.getDirectorName()));
                     } else {
                         // No names match the loan name, so we establish a new index and increment for the next loan
+                        loan.setDirectorIndex(directorIndex);
                         directorIndexes.put(loan.getDirectorName(), directorIndex);
                         directorIndex++;
                     }


### PR DESCRIPTION
Set director index when not present in order to fix template render issue when accounts only include LTD, without a DR

Addresses bug raised in BI-4408