### PR TITLE
Add director loan index to loan

### DIFF
--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/model/ixbrl/loanstodirectors/Loan.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/model/ixbrl/loanstodirectors/Loan.java
@@ -4,17 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Loan {
 
-    public Loan(String directorName, String description, Long balanceAtPeriodStart,
-                Long advancesCreditsMade, Long advancesCreditsRepaid, Long balanceAtPeriodEnd) {
-
-        this.directorName = directorName;
-        this.description = description;
-        this.balanceAtPeriodStart = balanceAtPeriodStart;
-        this.advancesCreditsMade = advancesCreditsMade;
-        this.advancesCreditsRepaid = advancesCreditsRepaid;
-        this.balanceAtPeriodEnd = balanceAtPeriodEnd;
-    }
-
     @JsonProperty("director_name")
     private String directorName;
 
@@ -35,6 +24,20 @@ public class Loan {
 
     @JsonProperty("balance_at_period_end")
     private Long balanceAtPeriodEnd;
+
+    @JsonProperty("director_loan_index")
+    private Integer directorLoanIndex;
+
+    public Loan(String directorName, String description, Long balanceAtPeriodStart,
+                Long advancesCreditsMade, Long advancesCreditsRepaid, Long balanceAtPeriodEnd) {
+
+        this.directorName = directorName;
+        this.description = description;
+        this.balanceAtPeriodStart = balanceAtPeriodStart;
+        this.advancesCreditsMade = advancesCreditsMade;
+        this.advancesCreditsRepaid = advancesCreditsRepaid;
+        this.balanceAtPeriodEnd = balanceAtPeriodEnd;
+    }
 
     public String getDirectorName() {
         return directorName;
@@ -90,5 +93,13 @@ public class Loan {
 
     public void setBalanceAtPeriodEnd(Long balanceAtPeriodEnd) {
         this.balanceAtPeriodEnd = balanceAtPeriodEnd;
+    }
+
+    public Integer getDirectorLoanIndex() {
+        return directorLoanIndex;
+    }
+
+    public void setDirectorLoanIndex(Integer directorLoanIndex) {
+        this.directorLoanIndex = directorLoanIndex;
     }
 }


### PR DESCRIPTION
The iXBRL being generated is wrong when there are Loans To Directors.
 Each loan is supposed to have a number that identifies it within the
 scope of the director who is associated with that loan.
For example, director 1 could have loans labelled 1,2,3; Director 2:
 loan 1; Director 3: loans 1,2.
This commit fixes this issue in the code. An associated commit in
 company-accounts.api.ch.gov.uk fixes the template to use the loan
 id.
This index is an incrementing number that distinguishes the loans
 for a given director. When a director has several loans, each
of those loans will have a different Loan.directorLoanIndex value.
Changed Loan to add this field.
Changed SmallFullIXBRLMapperDecorator to clarify existing code
 and to add new logic for tracking each directors loan indexes
 and applying them to the loans.

No new unit tests added.
Some code issues addressed.
No new issues introduced.
Tested manually.