### PR TITLE
Resolves issues with context ref on ixbrl

### DIFF
--- a/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
+++ b/document-generator-accounts/src/main/java/uk/gov/companieshouse/document/generator/accounts/mapping/smallfull/mappers/SmallFullIXBRLMapperDecorator.java
@@ -73,6 +73,7 @@ public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMap
     private static final int INDEX_OF_FIRST_DIRECTOR_THAT_DID_NOT_APPROVE_DIRECTORS_REPORT = 2;
     private static final int INDEX_OF_DIRECTOR_THAT_APPROVED_DIRECTORS_REPORT = 1;
     private static final int INDEX_OF_FIRST_LOAN_FOR_A_DIRECTOR = 1;
+    private static final String DIRECTOR_NAME_NOT_PROVIDED = "Not provided";
 
     @Autowired
     @Qualifier("delegate")
@@ -448,6 +449,8 @@ public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMap
             }
         }
 
+        directorIndexes.put(DIRECTOR_NAME_NOT_PROVIDED, directorIndexes.size() + 1);
+
         directorsReport.setSortedDirectors(directors);
 
         directorsReport.setApproval(directorsApproval);
@@ -586,10 +589,10 @@ public abstract class SmallFullIXBRLMapperDecorator implements SmallFullIXBRLMap
                         loanApi.getBreakdown().getAdvancesCreditsRepaid(),
                         loanApi.getBreakdown().getBalanceAtPeriodEnd());
 
-                String directorName = StringUtils.isBlank(loan.getDirectorName()) ? "Not provided" : loan.getDirectorName();
+                String directorName = StringUtils.isBlank(loan.getDirectorName()) ? DIRECTOR_NAME_NOT_PROVIDED : loan.getDirectorName();
 
                 if (smallFull.getDirectorsReport() != null) {
-                    directorIndexes.put("Not provided", directorIndexes.size());
+
                     // If DR is present, set index according to `directorIndexes`, which corresponds with DR data
                     loan.setDirectorIndex(directorIndexes.get(directorName));
                 } else {


### PR DESCRIPTION
This commit resolves the issue where previously code was assinging the same index as one of the already present directors
and it was causing validation to fail. This change will make sure all the loans with directors name provided or not will have a unique
context ref