### PR TITLE
Update version of api-sdk-java to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
         <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
 
-        <api-sdk-java.version>4.2.43</api-sdk-java.version>
+        <api-sdk-java.version>4.3.7</api-sdk-java.version>
 
         <gson.version>2.8.0</gson.version>
 


### PR DESCRIPTION
Update api-sdk-version to 4.3.7

This version includes the new called up share capital not paid field which is required for the abridged accounts template.

BI-6648