### PR TITLE
add logic to not show the officer is active if the company is dissolved

### DIFF
--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -530,11 +530,18 @@
 
                 <li>{{.officer_role}} {{.name}}
 
-                    {{ if .resigned_on }}
-                        <span id="officer-status-tag-resigned" class="status-tag ceased-tag">Resigned</span>
+                    {{if ne $companyRegistrationInformation.status.company_status "Dissolved"}}
+                        {{if .resigned_on}}
+                            <span id="officer-status-tag-resigned" class="status-tag ceased-tag">Resigned</span>
                         {{else}}
-                        <span id="officer-status-tag-active" class="status-tag">Active</span>
+                            <span id="officer-status-tag-active" class="status-tag">Active</span>
                         {{end}}
+                    {{else}}
+                        {{if .resigned_on}}
+                            <span id="officer-status-tag-resigned" class="status-tag ceased-tag">Resigned</span>
+                        {{end}}
+                    {{end}}
+
                     </li>
 
                     {{if .nationality}}


### PR DESCRIPTION
Added logic to the company report if a company is dissolved do not show active status next to officers 

Resolves: BI-9125