### PR TITLE
add check on report if postcode is present for additional comma

### DIFF
--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -595,11 +595,13 @@
                             {{end}}
 
                             {{if .address.country}}
-                                {{index .address "country"}},
+                                {{index .address "country"}}
+                                {{if .address.postal_code}},
+                                {{end}}
                             {{end}}
 
                             {{if .address.postal_code}}
-                                {{index .address "postal_code"}}
+                            {{index .address "postal_code"}}
                             {{end}}
 
                         </li>


### PR DESCRIPTION
Checks if postcode is present for overseas address for officers and will remove the comma 

Resolves: BI-9242