### PR TITLE
Remove log4j2 from start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -25,4 +25,4 @@ else
     source "${APP_DIR}/app_env"
 fi
 
-exec java ${JAVA_MEM_ARGS} -jar -Dserver.port="${PORT}" -Dlog4j.configurationFile="${APP_DIR}/log4j2.xml" "${APP_DIR}/document-generator.jar"
+exec java ${JAVA_MEM_ARGS} -jar -Dserver.port="${PORT}" "${APP_DIR}/document-generator.jar"


### PR DESCRIPTION
Ran `mvn dependency:tree|grep log4j-core` following the simple instructions - no output was returned therefor can be considered safe.