### PR TITLE
security upgrades jan 22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ bin/
 .idea/
 *.iml
 
+# VSCode
+.vscode/
+
 # Mac files
 .DS_Store
 ._*

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Which returns the DocumentInfo model which will contain  String data, String tem
 
 ### document-generator-prosecution
 
-The document-generator-prosecution module is a sub module within document-generator, which is the prosecution implementation of the DocumentInfoService that contains the method getDocumentInfo. 
+The document-generator-prosecution module is a sub module within document-generator, which is the prosecution implementation of the DocumentInfoService that contains the method getDocumentInfo.
 Which returns the DocumentInfo model which will contain  String data, String templateName, String assetId, String path, String descriptionIdentifier and a Map<String, String> description Values for Ultimatum and SJP letters.
 
 ## Docker

--- a/document-generator-api/pom.xml
+++ b/document-generator-api/pom.xml
@@ -23,15 +23,12 @@
         <!-- JDK Version -->
         <jdk.version>1.8</jdk.version>
 
-        <apache-http-components.version>4.5.2</apache-http-components.version>
+        <apache-http-components.version>4.5.13</apache-http-components.version>
         
-        <commons-io.version>2.4</commons-io.version>
-
-        <snakeyaml.version>1.17</snakeyaml.version>
-
-        <gson.version>2.8.0</gson.version>
+        <commons-io.version>2.7</commons-io.version>
 
     </properties>
+    
     <dependencies>
         <dependency>
             <groupId>commons-io</groupId>

--- a/document-generator-common/pom.xml
+++ b/document-generator-common/pom.xml
@@ -17,10 +17,6 @@
     <name>document-generator-common</name>
     <description>Module for holding common classes/methods used in document generation</description>
 
-    <properties>
-        <snakeyaml.version>1.17</snakeyaml.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.yaml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,15 @@
 
         <api-sdk-java.version>4.3.7</api-sdk-java.version>
 
-        <gson.version>2.8.0</gson.version>
-
         <!-- Structured logging -->
         <structured-logging.version>1.4.0-rc2</structured-logging.version>
 
         <environment-reader-library.version>1.2.0-rc1</environment-reader-library.version>
+
+        <!-- Third party libs used in child poms -->
+        <snakeyaml.version>1.26</snakeyaml.version>
+        <gson.version>2.8.9</gson.version>
+
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Update the following libraries for security warnings: snakeyaml, httpclient, commons-io, gson

Also moved any common property (that was updated) to the parent pom

Ref: BI-9903

jar checked OK for new versions

$ jar -tf document-generator-unversioned.jar | grep snakeyaml
BOOT-INF/lib/snakeyaml-1.26.jar
$  jar -tf document-generator-unversioned.jar | grep  httpclient
BOOT-INF/lib/httpclient-4.5.13.jar
$  jar -tf document-generator-unversioned.jar | grep  commons-io
BOOT-INF/lib/commons-io-2.7.jar
$  jar -tf document-generator-unversioned.jar | grep  gson
BOOT-INF/lib/gson-2.8.9.jar