### PR TITLE
ROE-134: Correct next filing date due to next confirmation statement for ROEs

### DIFF
--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -416,7 +416,7 @@
 
     {{if eq $companyRegistrationInformation.company_type.type "Registered overseas entity"}}
 
-        {{if or $keyFilingDates.next_made_up_to $keyFilingDates.last_confirmation_statement}}
+        {{if or $keyFilingDates.next_confirmation_statement $keyFilingDates.last_confirmation_statement}}
             <h3 class="heading-small">Key filing dates</h3>
         {{end}}
 
@@ -424,8 +424,8 @@
             Last annual update date: {{$keyFilingDates.last_confirmation_statement}}
             <br>
         {{end}}
-        {{if $keyFilingDates.next_made_up_to}}
-            Next annual update date: {{$keyFilingDates.next_made_up_to}}
+        {{if $keyFilingDates.next_confirmation_statement}}
+            Next annual update due: {{$keyFilingDates.next_confirmation_statement}}
         {{end}}
 
     {{else}}


### PR DESCRIPTION
* Use the right field for the next due date as clarified in this chat: https://companieshouse.slack.com/archives/C02TZ3RCGG5/p1649345961923319.
* Makes more sense to have the "pair" of fields `last_confirmation_statement` and `next_confirmation_statement` upon reflection too!