### PR TITLE
ROE-368: Render super secure BOs and PSCs in company report

### DIFF
--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -4,5 +4,8 @@ custom_build(
   deps = [
     './',
   ],
-  ignore = ['**/target']
+  ignore = [
+    '**/target',
+    '**/company-report.html',
+  ]
 )

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapper.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapper.java
@@ -29,6 +29,7 @@ public abstract class ApiToPscMapper {
     private static final String PSC_DESCRIPTIONS = "PSC_DESCRIPTIONS";
     private static final String IDENTIFIER = "short_description";
     private static final String SUPER_SECURE_DESCRIPTION_IDENTIFIER = "super_secure_description";
+    private static final String SUPER_SECURE_PERSON_WITH_SIGNIFICANT_CONTROL_KIND = "super-secure-persons-with-significant-control";
     private static final String SUPER_SECURE_BENEFICIAL_OWNER_KIND = "super-secure-beneficial-owner";
     private static final String D_MMMM_UUUU = "d MMMM uuuu";
 
@@ -90,13 +91,18 @@ public abstract class ApiToPscMapper {
     }
 
     @AfterMapping
-    protected void setSuperSecureBeneficialOwnerDescription(PscApi pscApi, @MappingTarget Psc psc) {
+    protected void setSuperSecureDescription(PscApi pscApi, @MappingTarget Psc psc) {
 
-        if (pscApi != null && pscApi.getKind() != null && pscApi.getKind().equals(SUPER_SECURE_BENEFICIAL_OWNER_KIND) ) {
+        if (pscApi == null || pscApi.getKind() == null) {
+            return;
+        }
+
+        if (pscApi.getKind().equals(SUPER_SECURE_BENEFICIAL_OWNER_KIND) ||
+                pscApi.getKind().equals(SUPER_SECURE_PERSON_WITH_SIGNIFICANT_CONTROL_KIND)) {
             final String description = retrieveApiEnumerationDescription
                     .getApiEnumerationDescription(PSC_DESCRIPTIONS, SUPER_SECURE_DESCRIPTION_IDENTIFIER,
-                            SUPER_SECURE_BENEFICIAL_OWNER_KIND, getDebugMap(SUPER_SECURE_BENEFICIAL_OWNER_KIND));
-            psc.setSuperSecureBeneficialOwnerDescription(description);
+                            pscApi.getKind(), getDebugMap(pscApi.getKind()));
+            psc.setSuperSecureDescription(description);
         }
     }
 

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapper.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapper.java
@@ -28,6 +28,8 @@ public abstract class ApiToPscMapper {
     private static final String ENUMERATION_MAPPING = "Enumeration mapping :";
     private static final String PSC_DESCRIPTIONS = "PSC_DESCRIPTIONS";
     private static final String IDENTIFIER = "short_description";
+    private static final String SUPER_SECURE_DESCRIPTION_IDENTIFIER = "super_secure_description";
+    private static final String SUPER_SECURE_BENEFICIAL_OWNER_KIND = "super-secure-beneficial-owner";
     private static final String D_MMMM_UUUU = "d MMMM uuuu";
 
     @Mappings({
@@ -84,6 +86,17 @@ public abstract class ApiToPscMapper {
         if (pscApi != null && pscApi.getNotifiedOn() != null) {
             LocalDate notifiedOn = pscApi.getNotifiedOn();
             psc.setNotifiedOn(notifiedOn.format(getFormatter()));
+        }
+    }
+
+    @AfterMapping
+    protected void setSuperSecureBeneficialOwnerDescription(PscApi pscApi, @MappingTarget Psc psc) {
+
+        if (pscApi != null && pscApi.getKind() != null && pscApi.getKind().equals(SUPER_SECURE_BENEFICIAL_OWNER_KIND) ) {
+            final String description = retrieveApiEnumerationDescription
+                    .getApiEnumerationDescription(PSC_DESCRIPTIONS, SUPER_SECURE_DESCRIPTION_IDENTIFIER,
+                            SUPER_SECURE_BENEFICIAL_OWNER_KIND, getDebugMap(SUPER_SECURE_BENEFICIAL_OWNER_KIND));
+            psc.setSuperSecureBeneficialOwnerDescription(description);
         }
     }
 

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/pscs/items/Psc.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/pscs/items/Psc.java
@@ -41,6 +41,12 @@ public class Psc {
     @JsonProperty("principal_office_address")
     private Address principalOfficeAddress;
 
+    @JsonProperty("kind")
+    private String kind;
+
+    @JsonProperty("super_secure_beneficial_owner_description")
+    private String superSecureBeneficialOwnerDescription;
+
     public Address getAddress() {
         return address;
     }
@@ -127,6 +133,22 @@ public class Psc {
 
     public void setPrincipalOfficeAddress(Address principalOfficeAddress) {
         this.principalOfficeAddress = principalOfficeAddress;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public String getSuperSecureBeneficialOwnerDescription() {
+        return superSecureBeneficialOwnerDescription;
+    }
+
+    public void setSuperSecureBeneficialOwnerDescription(String superSecureBeneficialOwnerDescription) {
+        this.superSecureBeneficialOwnerDescription = superSecureBeneficialOwnerDescription;
     }
 }
 

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/pscs/items/Psc.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/model/document/items/pscs/items/Psc.java
@@ -44,8 +44,8 @@ public class Psc {
     @JsonProperty("kind")
     private String kind;
 
-    @JsonProperty("super_secure_beneficial_owner_description")
-    private String superSecureBeneficialOwnerDescription;
+    @JsonProperty("super_secure_description")
+    private String superSecureDescription;
 
     public Address getAddress() {
         return address;
@@ -143,12 +143,12 @@ public class Psc {
         this.kind = kind;
     }
 
-    public String getSuperSecureBeneficialOwnerDescription() {
-        return superSecureBeneficialOwnerDescription;
+    public String getSuperSecureDescription() {
+        return superSecureDescription;
     }
 
-    public void setSuperSecureBeneficialOwnerDescription(String superSecureBeneficialOwnerDescription) {
-        this.superSecureBeneficialOwnerDescription = superSecureBeneficialOwnerDescription;
+    public void setSuperSecureDescription(String superSecureDescription) {
+        this.superSecureDescription = superSecureDescription;
     }
 }
 

--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -887,7 +887,7 @@
             {{range $pscs.items}}
                 <ul class="list list-bullet">
 
-                    <li>{{.name}}
+                    <li>{{if eq .kind "super-secure-beneficial-owner"}}Beneficial owner{{else}}{{.name}}{{end}}
 
                         {{ if .ceased_on }}
                         <span id="pscs-status-tag-resigned" class="status-tag ceased-tag">Ceased</span>
@@ -895,6 +895,10 @@
                         <span id="pscs-status-tag-active" class="status-tag">Active</span>
                         {{end}}
                     </li>
+
+                    {{if eq .kind "super-secure-beneficial-owner"}}
+                        <b>{{.super_secure_beneficial_owner_description}}</b>
+                    {{end}}
 
                     {{if .is_sanctioned}}
                     <li> Sanction declared </li>
@@ -1037,9 +1041,8 @@
                     {{end}}
                 </ul>
 
-                </li>
-                <hr>
                 {{end}}
+            <hr>
             {{end}}
         {{end}}
 

--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -887,7 +887,13 @@
             {{range $pscs.items}}
                 <ul class="list list-bullet">
 
-                    <li>{{if eq .kind "super-secure-beneficial-owner"}}Beneficial owner{{else}}{{.name}}{{end}}
+                    <li>{{if eq .kind "super-secure-beneficial-owner"}}
+                            Beneficial owner
+                        {{else if eq .kind "super-secure-persons-with-significant-control"}}
+                            Protected person with significant control
+                        {{else}}
+                            {{.name}}
+                        {{end}}
 
                         {{ if .ceased_on }}
                         <span id="pscs-status-tag-resigned" class="status-tag ceased-tag">Ceased</span>
@@ -896,8 +902,8 @@
                         {{end}}
                     </li>
 
-                    {{if eq .kind "super-secure-beneficial-owner"}}
-                        <b>{{.super_secure_beneficial_owner_description}}</b>
+                    {{if or (eq .kind "super-secure-beneficial-owner") (eq .kind "super-secure-persons-with-significant-control")}}
+                        <b>{{.super_secure_description}}</b>
                     {{end}}
 
                     {{if .is_sanctioned}}

--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -869,7 +869,7 @@
             {{if $pscs.active_count}}
                 {{$pscs.active_count}} active {{if eq $pscs.active_count 1.0}} beneficial owner {{else}} beneficial owners {{end}}
             {{else}}
-                beneficial owners
+                0 beneficial owners
             {{end}} /
         {{else}}
             {{if $pscs.active_count}}

--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -814,8 +814,7 @@
             Beneficial owners:
         {{else}}
             Persons with significant control:
-        {{end}}
-    </h2>
+        {{end}}<br>
 
         {{if $exemptions}}
             {{if $exemptions.active_exemption}}
@@ -864,7 +863,6 @@
                     </ul>
         {{end}}
 
-    <h2 class="heading-medium">
         {{if eq $companyRegistrationInformation.company_type.type "Registered overseas entity"}}
             {{if $pscs.active_count}}
                 {{$pscs.active_count}} active {{if eq $pscs.active_count 1.0}} beneficial owner {{else}} beneficial owners {{end}}

--- a/document-generator-company-report/src/test/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapperTest.java
+++ b/document-generator-company-report/src/test/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapperTest.java
@@ -54,6 +54,10 @@ class ApiToPscMapperTest {
 
     private final String[] NATURE_OF_CONTROL = new String[]{"test1", "test2", "test3"};
 
+    private static final String SUPER_SECURE_PERSON_WITH_SIGNIFICANT_CONTROL_KIND = "super-secure-persons-with-significant-control";
+    private static final String SUPER_SECURE_BENEFICIAL_OWNER_KIND = "super-secure-beneficial-owner";
+
+
     @InjectMocks
     private ApiToPscMapper apiToPscMapper = new ApiToPscMapperImpl();
 
@@ -79,7 +83,7 @@ class ApiToPscMapperTest {
     @DisplayName("tests single PSC data maps to PSC model")
     void testApiToPSCMaps() {
 
-        PscApi pscApi = createPscApi();
+        PscApi pscApi = createPscApiWithKind(SUPER_SECURE_PERSON_WITH_SIGNIFICANT_CONTROL_KIND);
 
         when(mockRetrieveApiEnumerations.getApiEnumerationDescription(anyString(), anyString(),
                 anyString(), any())).thenReturn(MAPPED_VALUE);
@@ -113,18 +117,20 @@ class ApiToPscMapperTest {
                 psc.getNaturesOfControl().get(1).getNaturesOfControlDescription());
         assertEquals(MAPPED_VALUE,
                 psc.getNaturesOfControl().get(2).getNaturesOfControlDescription());
+
+        assertEquals(MAPPED_VALUE, psc.getSuperSecureDescription());
     }
 
     @Test
     @DisplayName("beneficial owner fields are mapped correctly to model for ROE")
     void testApiToPscMapsForBeneficialOwners() {
 
-        PscApi pscApi = createPscApi();
+        final PscApi pscApi = createPscApiWithKind(SUPER_SECURE_BENEFICIAL_OWNER_KIND);
 
         when(mockRetrieveApiEnumerations.getApiEnumerationDescription(anyString(), anyString(),
                 anyString(), any())).thenReturn(MAPPED_VALUE);
 
-        Psc psc = apiToPscMapper.apiToPsc(pscApi);
+        final Psc psc = apiToPscMapper.apiToPsc(pscApi);
 
         assertNotNull(psc);
 
@@ -139,11 +145,12 @@ class ApiToPscMapperTest {
         assertEquals(POSTAL_CODE, psc.getPrincipalOfficeAddress().getPostalCode());
         assertEquals(REGION, psc.getPrincipalOfficeAddress().getRegion());
         assertEquals(PREMISE, psc.getPrincipalOfficeAddress().getPremises());
+
+        assertEquals(MAPPED_VALUE, psc.getSuperSecureDescription());
     }
 
-
-    private PscApi createPscApi() {
-        PscApi pscApi = new PscApi();
+    private PscApi createPscApiWithKind(final String kind) {
+        final PscApi pscApi = new PscApi();
 
         final Address address = createAddress();
         pscApi.setAddress(address);
@@ -158,6 +165,7 @@ class ApiToPscMapperTest {
 
         pscApi.setSanctioned(IS_SANCTIONED);
         pscApi.setPrincipalOfficeAddress(address);
+        pscApi.setKind(kind);
 
         return pscApi;
     }


### PR DESCRIPTION
Functional changes made:
* Minor content and layout tweaks.
* Rendering of a label instead of name for super secure BOs and PSCs.
* Rendering of a specific description for super secure BOs and PSCs.

Build change made:
* Tilt build tweak to reduce number of redundant builds in live update mode.

Changes **not** made:
* Any changes for PSC statements. Further changes concerning statements can be addressed in a separate PR should they be required.
