### PR TITLE
Feature/bi 13996 add protected person secure description

### DIFF
--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/handler/CompanyReportDataHandler.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/handler/CompanyReportDataHandler.java
@@ -200,9 +200,11 @@ public class CompanyReportDataHandler {
 
     private void setPscsData(String companyNumber, String requestId,
         CompanyReportApiData companyReportApiData, CompanyProfileApi companyProfileApi) {
+        LOG.info("set PSC data before key");
         if (companyProfileApi.getLinks().containsKey(PSCS_KEY)) {
             try {
                 PscsApi pscsApi = getPscs(companyNumber, requestId);
+                LOG.info("Company report data handler" + pscsApi.getItems());
                 companyReportApiData.setPscsApi(pscsApi);
 
             } catch (HandlerException he) {
@@ -214,8 +216,10 @@ public class CompanyReportDataHandler {
 
     private void setOfficersData(String companyNumber, String requestId,
         CompanyReportApiData companyReportApiData, CompanyProfileApi companyProfileApi) {
+        LOG.info("set officers data before key");
         if (companyProfileApi.getLinks().containsKey(OFFICERS_KEY)) {
             try {
+                LOG.info("set officers data after key");
                 OfficersApi officersApi = getOfficers(companyNumber, requestId);
                 companyReportApiData.setOfficersApi(officersApi);
             } catch (HandlerException he) {

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/handler/CompanyReportDataHandler.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/handler/CompanyReportDataHandler.java
@@ -200,11 +200,9 @@ public class CompanyReportDataHandler {
 
     private void setPscsData(String companyNumber, String requestId,
         CompanyReportApiData companyReportApiData, CompanyProfileApi companyProfileApi) {
-        LOG.info("set PSC data before key");
         if (companyProfileApi.getLinks().containsKey(PSCS_KEY)) {
             try {
                 PscsApi pscsApi = getPscs(companyNumber, requestId);
-                LOG.info("Company report data handler" + pscsApi.getItems());
                 companyReportApiData.setPscsApi(pscsApi);
 
             } catch (HandlerException he) {
@@ -216,10 +214,8 @@ public class CompanyReportDataHandler {
 
     private void setOfficersData(String companyNumber, String requestId,
         CompanyReportApiData companyReportApiData, CompanyProfileApi companyProfileApi) {
-        LOG.info("set officers data before key");
         if (companyProfileApi.getLinks().containsKey(OFFICERS_KEY)) {
             try {
-                LOG.info("set officers data after key");
                 OfficersApi officersApi = getOfficers(companyNumber, requestId);
                 companyReportApiData.setOfficersApi(officersApi);
             } catch (HandlerException he) {

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapper.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapper.java
@@ -92,7 +92,7 @@ public abstract class ApiToPscMapper {
 
     @AfterMapping
     protected void setSuperSecureDescription(PscApi pscApi, @MappingTarget Psc psc) {
-        String description = "";
+        var description = "";
         if (pscApi == null || pscApi.getKind() == null) {
             return;
         }

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapper.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapper.java
@@ -12,6 +12,8 @@ import uk.gov.companieshouse.document.generator.common.descriptions.RetrieveApiE
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.common.DateDayMonthYear;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.pscs.items.NaturesOfControl;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.pscs.items.Psc;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.time.LocalDate;
 import java.time.Month;
@@ -21,6 +23,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static uk.gov.companieshouse.document.generator.company.report.CompanyReportDocumentInfoServiceImpl.MODULE_NAME_SPACE;
+
+
 @RequestScope
 @Mapper(componentModel = "spring")
 public abstract class ApiToPscMapper {
@@ -29,7 +34,9 @@ public abstract class ApiToPscMapper {
     private static final String PSC_DESCRIPTIONS = "PSC_DESCRIPTIONS";
     private static final String IDENTIFIER = "short_description";
     private static final String SUPER_SECURE_DESCRIPTION_IDENTIFIER = "super_secure_description";
-    private static final String SUPER_SECURE_PERSON_WITH_SIGNIFICANT_CONTROL_KIND = "super-secure-persons-with-significant-control";
+    private static final String SUPER_SECURE_PERSON_WITH_SIGNIFICANT_CONTROL_KIND = "super-secure-person-with-significant-control";
+    private static final String SUPER_SECURE_PERSON_WITH_SIGNIFICANT_CONTROL_DESCRIPTION = "super-secure-persons-with-significant-control";
+    private static final String SUPER_SECURE_BENEFICIAL_OWNER_KIND_DESCRIPTION = "super-secure-beneficial-owner";
     private static final String SUPER_SECURE_BENEFICIAL_OWNER_KIND = "super-secure-beneficial-owner";
     private static final String D_MMMM_UUUU = "d MMMM uuuu";
 
@@ -58,7 +65,6 @@ public abstract class ApiToPscMapper {
 
     @AfterMapping
     protected void setCeasedOnDate(PscApi pscApi, @MappingTarget Psc psc) {
-
         if (pscApi != null && pscApi.getCeasedOn() != null) {
             LocalDate ceasedOn = pscApi.getCeasedOn();
             psc.setCeasedOn(ceasedOn.format(getFormatter()));
@@ -67,7 +73,6 @@ public abstract class ApiToPscMapper {
 
     @AfterMapping
     protected void setDateOfBirth(PscApi pscApi, @MappingTarget Psc psc) {
-
         if (pscApi != null && pscApi.getDateOfBirth() != null) {
             DateDayMonthYear dob = new DateDayMonthYear();
             String monthString = getNameOfMonth(pscApi);
@@ -92,19 +97,21 @@ public abstract class ApiToPscMapper {
 
     @AfterMapping
     protected void setSuperSecureDescription(PscApi pscApi, @MappingTarget Psc psc) {
-
+        String description = "";
         if (pscApi == null || pscApi.getKind() == null) {
             return;
         }
-
-        if (pscApi.getKind().equals(SUPER_SECURE_BENEFICIAL_OWNER_KIND) ||
-                pscApi.getKind().equals(SUPER_SECURE_PERSON_WITH_SIGNIFICANT_CONTROL_KIND)) {
-            final String description = retrieveApiEnumerationDescription
+        if (pscApi.getKind().equals(SUPER_SECURE_BENEFICIAL_OWNER_KIND)) {
+             description = retrieveApiEnumerationDescription
                     .getApiEnumerationDescription(PSC_DESCRIPTIONS, SUPER_SECURE_DESCRIPTION_IDENTIFIER,
-                            pscApi.getKind(), getDebugMap(pscApi.getKind()));
+                            SUPER_SECURE_BENEFICIAL_OWNER_KIND_DESCRIPTION, getDebugMap(pscApi.getKind()));
+        } else if (pscApi.getKind().equals(SUPER_SECURE_PERSON_WITH_SIGNIFICANT_CONTROL_KIND)) {
+             description = retrieveApiEnumerationDescription
+                    .getApiEnumerationDescription(PSC_DESCRIPTIONS, SUPER_SECURE_DESCRIPTION_IDENTIFIER,
+                            SUPER_SECURE_PERSON_WITH_SIGNIFICANT_CONTROL_DESCRIPTION, getDebugMap(pscApi.getKind()));
+        }
             psc.setSuperSecureDescription(description);
         }
-    }
 
     private List<NaturesOfControl> setNaturesOfControl(String[] naturesOfControl) {
 
@@ -118,6 +125,7 @@ public abstract class ApiToPscMapper {
                         .getApiEnumerationDescription(PSC_DESCRIPTIONS, IDENTIFIER,
                                 natureOfControl, getDebugMap(natureOfControl));
                 natures.setNaturesOfControlDescription(natureOfControlDescription);
+                System.out.println("NOC? " + natureOfControlDescription);
                 naturesOfControlList.add(natures);
             }
         }

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapper.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapper.java
@@ -12,8 +12,6 @@ import uk.gov.companieshouse.document.generator.common.descriptions.RetrieveApiE
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.common.DateDayMonthYear;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.pscs.items.NaturesOfControl;
 import uk.gov.companieshouse.document.generator.company.report.mapping.model.document.items.pscs.items.Psc;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.time.LocalDate;
 import java.time.Month;
@@ -22,8 +20,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static uk.gov.companieshouse.document.generator.company.report.CompanyReportDocumentInfoServiceImpl.MODULE_NAME_SPACE;
 
 
 @RequestScope
@@ -125,7 +121,6 @@ public abstract class ApiToPscMapper {
                         .getApiEnumerationDescription(PSC_DESCRIPTIONS, IDENTIFIER,
                                 natureOfControl, getDebugMap(natureOfControl));
                 natures.setNaturesOfControlDescription(natureOfControlDescription);
-                System.out.println("NOC? " + natureOfControlDescription);
                 naturesOfControlList.add(natures);
             }
         }

--- a/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapper.java
+++ b/document-generator-company-report/src/main/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapper.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-
 @RequestScope
 @Mapper(componentModel = "spring")
 public abstract class ApiToPscMapper {

--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -932,10 +932,9 @@
         {{if $pscs}}
             {{range $pscs.items}}
                 <ul class="list list-bullet">
-
                     <li>{{if eq .kind "super-secure-beneficial-owner"}}
                             Beneficial owner
-                        {{else if eq .kind "super-secure-persons-with-significant-control"}}
+                        {{else if eq .kind "super-secure-person-with-significant-control"}}
                             Protected person with significant control
                         {{else}}
                             {{.name}}
@@ -950,7 +949,7 @@
                         {{end}}
                     </li>
 
-                    {{if or (eq .kind "super-secure-beneficial-owner") (eq .kind "super-secure-persons-with-significant-control")}}
+                    {{if or (eq .kind "super-secure-beneficial-owner") (eq .kind "super-secure-person-with-significant-control")}}
                         <b>{{.super_secure_description}}</b>
                     {{end}}
 

--- a/document-generator-company-report/src/test/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapperTest.java
+++ b/document-generator-company-report/src/test/java/uk/gov/companieshouse/document/generator/company/report/mapping/mappers/pscs/ApiToPscMapperTest.java
@@ -54,7 +54,7 @@ class ApiToPscMapperTest {
 
     private final String[] NATURE_OF_CONTROL = new String[]{"test1", "test2", "test3"};
 
-    private static final String SUPER_SECURE_PERSON_WITH_SIGNIFICANT_CONTROL_KIND = "super-secure-persons-with-significant-control";
+    private static final String SUPER_SECURE_PERSON_WITH_SIGNIFICANT_CONTROL_KIND = "super-secure-person-with-significant-control";
     private static final String SUPER_SECURE_BENEFICIAL_OWNER_KIND = "super-secure-beneficial-owner";
 
 


### PR DESCRIPTION
Resolves [BI-13996](https://companieshouse.atlassian.net/browse/BI-13996)

- Fix string for  super-secure-pscs  `kind` to match correct kind definition from psc-api/DB ('Person' not 'Persons') in APItoPSC mapper as well as in the company-report template, so now any Protected Person belonging to the company will be accompanied by correct super secure definition paragraph to match behaviour within CHS when a company report is generated
- Update tests to also correct super-secure-pscs `kind` string


<img width="1431" alt="Screenshot 2024-10-08 at 12 53 14" src="https://github.com/user-attachments/assets/f8417a2e-010d-4426-bb2e-bb4f4a06f9b5">


[BI-13996]: https://companieshouse.atlassian.net/browse/BI-13996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ