### PR TITLE
CC-1546 - Remove broken linked CDN assets

### DIFF
--- a/document-generator-company-report/src/main/resources/company-report.html
+++ b/document-generator-company-report/src/main/resources/company-report.html
@@ -295,8 +295,6 @@
           }
         }
     </style>
-    <link href="https://d11ystzvnk2sve.cloudfront.net/stylesheets/assets-digital-cabinet-office-gov-uk-static/govuk-template.css" media="screen" rel="stylesheet" type="text/css">
-    <link href="https://d11ystzvnk2sve.cloudfront.net/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css">
 </head>
 <body id="page-container">
 


### PR DESCRIPTION
Work has [previously been done to make these assets redundant](
https://github.com/companieshouse/document-generator/pull/190) and given they've not been loading at all we can remove them rather than ensuring they're up-to-date.
